### PR TITLE
fix: mark bot stickers in chat history

### DIFF
--- a/packages/message/src/state/sticker.ts
+++ b/packages/message/src/state/sticker.ts
@@ -23,6 +23,7 @@ export interface ResolvedSticker {
 }
 
 const STICKER_TOKEN_REGEX = /\[\[sticker:([a-zA-Z0-9_-]+)\]\]/g;
+export const YUIJU_STICKER_ELEMENT_ATTR = "yuijuStickerKey";
 
 export class StickerState {
   private readonly registry = new Map<string, ResolvedSticker>();
@@ -132,6 +133,7 @@ export class StickerState {
           h("image", {
             url: `base64://${sticker.fileBuffer.toString("base64")}`,
             summary: sticker.key,
+            [YUIJU_STICKER_ELEMENT_ATTR]: sticker.key,
           }),
         );
       }

--- a/packages/message/src/utils/message/satori.ts
+++ b/packages/message/src/utils/message/satori.ts
@@ -1,6 +1,7 @@
 import type { h, Session } from "@satorijs/core";
 import type { Message as SatoriMessage } from "@satorijs/protocol";
 import { SUBJECT_NAME } from "@yuiju/utils";
+import { stickerState, YUIJU_STICKER_ELEMENT_ATTR } from "@/state/sticker";
 import { resolveSatoriImageDescription } from "./image";
 import type {
   HistoryMessageSegment,
@@ -173,6 +174,19 @@ async function projectSatoriElementsToHistoryContent(
     }
 
     if (element.type === "image" || element.type === "img") {
+      const stickerKey = String(element.attrs[YUIJU_STICKER_ELEMENT_ATTR] ?? "").trim();
+      const sticker = stickerKey ? stickerState.getByKey(stickerKey) : null;
+      if (sticker) {
+        content.push({
+          type: "sticker",
+          data: {
+            key: sticker.key,
+            description: sticker.description,
+          },
+        });
+        continue;
+      }
+
       content.push({
         type: "image",
         data: {

--- a/packages/message/src/utils/message/satori.ts
+++ b/packages/message/src/utils/message/satori.ts
@@ -13,6 +13,8 @@ import type {
 
 const HISTORY_TEXT_SEGMENT_LIMIT = 300;
 const HISTORY_TEXT_TRUNCATED_SUFFIX = "...[已截断]";
+const ONEBOT_STICKER_IMAGE_SUBTYPE = "1";
+const ONEBOT_STICKER_IMAGE_DESCRIPTION_PREFIX = "这是一个表情包，不是别人画给你的图。";
 
 export async function createStoredSatoriGroupMessage(
   session: Session,
@@ -187,10 +189,18 @@ async function projectSatoriElementsToHistoryContent(
         continue;
       }
 
+      const description = await resolveSatoriImageDescription(element, session);
+      const isOneBotStickerImage =
+        String(element.attrs.subType ?? "").trim() === ONEBOT_STICKER_IMAGE_SUBTYPE;
+
       content.push({
         type: "image",
         data: {
-          description: await resolveSatoriImageDescription(element, session),
+          description: isOneBotStickerImage
+            ? `${ONEBOT_STICKER_IMAGE_DESCRIPTION_PREFIX}${
+                description ? `图片内容：${description}` : ""
+              }`
+            : description,
         },
       });
       continue;

--- a/packages/message/src/utils/message/types.ts
+++ b/packages/message/src/utils/message/types.ts
@@ -68,6 +68,14 @@ export interface HistoryImageSegment {
   };
 }
 
+export interface HistoryStickerSegment {
+  type: "sticker";
+  data: {
+    key: string;
+    description: string;
+  };
+}
+
 export interface HistoryFaceSegment {
   type: "face";
   data: {
@@ -78,6 +86,7 @@ export interface HistoryFaceSegment {
 export type HistoryMessageSegment =
   | HistoryTextSegment
   | HistoryImageSegment
+  | HistoryStickerSegment
   | HistoryAtSegment
   | HistoryReplySegment
   | HistoryFaceSegment

--- a/packages/utils/src/prompt/message.ts
+++ b/packages/utils/src/prompt/message.ts
@@ -33,7 +33,7 @@ export const messageHistorySchemaPrompt = `
 - \`text\`：文本段，读取 \`data.text\`
 - \`at\`：@ 提及段，表示这条消息提到了某个对象；\`data.displayName\` 是被提到的人或全体成员
 - \`reply\`：引用/回复段，表示这条消息引用了另一条消息；\`data.speaker\` 是被引用消息的发言者，\`data.content\` 是被引用消息的内容段数组
-- \`image\`：用户或平台消息里的普通图片段，优先读取 \`data.description\` 作为图片内容描述
+- \`image\`：用户或平台消息里的图片段，优先读取 \`data.description\` 作为图片内容描述；如果描述以“这是一个表情包”开头，请理解为对方发来的聊天表情包反应，不要理解成别人画给你的图
 - \`sticker\`：${SUBJECT_NAME}(${NICKNAME}) 通过 \`[[sticker:key]]\` 主动发送的表情包段，读取 \`data.description\` 理解当时的情绪反应；这不是别人发来的图片，也不是用户画给你的图
 - \`face\`：QQ 表情段，读取 \`data.faceText\`
 

--- a/packages/utils/src/prompt/message.ts
+++ b/packages/utils/src/prompt/message.ts
@@ -33,7 +33,8 @@ export const messageHistorySchemaPrompt = `
 - \`text\`：文本段，读取 \`data.text\`
 - \`at\`：@ 提及段，表示这条消息提到了某个对象；\`data.displayName\` 是被提到的人或全体成员
 - \`reply\`：引用/回复段，表示这条消息引用了另一条消息；\`data.speaker\` 是被引用消息的发言者，\`data.content\` 是被引用消息的内容段数组
-- \`image\`：图片或表情图片段，优先读取 \`data.description\` 作为图片内容描述
+- \`image\`：用户或平台消息里的普通图片段，优先读取 \`data.description\` 作为图片内容描述
+- \`sticker\`：${SUBJECT_NAME}(${NICKNAME}) 通过 \`[[sticker:key]]\` 主动发送的表情包段，读取 \`data.description\` 理解当时的情绪反应；这不是别人发来的图片，也不是用户画给你的图
 - \`face\`：QQ 表情段，读取 \`data.faceText\`
 
 读取 \`reply\` 时，请把它理解为当前消息附带的引用上下文；它不会改变当前消息最外层的 \`speaker\`。
@@ -128,11 +129,13 @@ export function buildStickerPromptSection(stickers: StickerPromptItem[]): string
   return `
 ## 表情包
 表情包可以作为聊天语气的一部分，用来补充情绪、调侃、撒娇、吐槽、开心、惊讶、害羞、委屈或轻松收尾。
+这些表情包是你自己可选择发送的聊天反应贴图；输出 \`[[sticker:key]]\` 表示你要发送这个表情包，不表示用户发来了一张图，也不表示有人给你画了图。
 当回复本身较短、文字情绪不够传神，或只想用一个小反应接住对方时，应优先考虑自然使用 1 个表情包。
 被调侃、轻微害羞、尴尬、委屈、炸毛、发懵、吐槽、轻松玩笑、只需要短短回应时，都是适合使用表情包的场景。
 表情包可以单独作为一行回复，也可以跟在一句短回复后面。
 格式必须是 \`[[sticker:key]]\`，key 只能从下方列表选择，不能写路径或自造 key；如果和文字一起使用，一般放在回复最后。
 同一条回复最多使用 1 个表情包；不要每次都用，也不要连续多轮高频使用。
+当你在历史消息里看到自己发出的 \`sticker\` 段时，只把它当成你当时的情绪反应，不要围绕“这张图是谁画的”“我收下了”展开。
 可用列表：
 ${stickerList}
 格式示例：


### PR DESCRIPTION
## Summary
- Mark bot-sent sticker elements with an internal sticker key before sending.
- Project bot-sent stickers into chat history as a dedicated sticker segment instead of a normal image.
- Clarify in the chat prompt that [[sticker:key]] is Yuiju's own reaction sticker, not a user-submitted drawing or image.

## Issue
Fixes #84

## Self-check
- The bad case is addressed at both data projection and prompt levels.
- Existing user/platform images still use the normal image path.

## Verification
- pre-commit lint-staged passed.
- pnpm run type-check passed.