### PR TITLE
feat: add person memory tests and layered diary summaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint-staged": "lint-staged",
     "demo:message": "pnpm --filter @yuiju/message run demo",
     "demo:world": "pnpm --filter @yuiju/world run demo",
+    "test:utils": "pnpm --filter @yuiju/utils run test",
     "stop": "pm2 stop ecosystem.config.js",
     "restart": "pm2 restart ecosystem.config.js",
     "start": "pm2 start ecosystem.config.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,6 +9,7 @@
     "./env": "./src/env.ts"
   },
   "scripts": {
+    "test": "vitest run",
     "type-check": "tsc --noEmit"
   },
   "keywords": [],

--- a/packages/utils/src/db/index.ts
+++ b/packages/utils/src/db/index.ts
@@ -1,4 +1,5 @@
 export * from "./connect";
 export * from "./operations";
 export * from "./schema/memory-diary.schema";
+export * from "./schema/memory-diary-summary.schema";
 export * from "./schema/memory-episode.schema";

--- a/packages/utils/src/db/operations/index.ts
+++ b/packages/utils/src/db/operations/index.ts
@@ -1,2 +1,3 @@
 export * from "./memory-diary";
+export * from "./memory-diary-summary";
 export * from "./memory-episode";

--- a/packages/utils/src/db/operations/memory-diary-summary.ts
+++ b/packages/utils/src/db/operations/memory-diary-summary.ts
@@ -1,0 +1,147 @@
+import type { MemoryDiarySummaryPeriod } from "../../memory/diary";
+import { hasSyncMongoUri, type MongoReadSource } from "../connect";
+import {
+  getMemoryDiarySummaryModel,
+  type IMemoryDiarySummary,
+} from "../schema/memory-diary-summary.schema";
+
+export interface MemoryDiarySummaryWriteInput {
+  subject: string;
+  period: MemoryDiarySummaryPeriod;
+  periodStartDate: Date;
+  periodEndDate: Date;
+  text: string;
+  isDev?: boolean;
+}
+
+export interface GetMemoryDiarySummariesOptions {
+  limit?: number;
+  skip?: number;
+  subject?: string;
+  period?: MemoryDiarySummaryPeriod;
+  isDev?: boolean;
+  periodStartDateAfter?: Date;
+  periodStartDateBefore?: Date;
+  sortDirection?: "asc" | "desc";
+  readFrom?: MongoReadSource;
+}
+
+function buildMemoryDiarySummaryFilter(
+  options: GetMemoryDiarySummariesOptions = {},
+): Record<string, unknown> {
+  const filter: Record<string, unknown> = {};
+
+  if (options.subject) {
+    filter.subject = options.subject;
+  }
+  if (options.period) {
+    filter.period = options.period;
+  }
+  if (typeof options.isDev === "boolean") {
+    filter.isDev = options.isDev;
+  }
+  if (options.periodStartDateAfter || options.periodStartDateBefore) {
+    filter.periodStartDate = {};
+    if (options.periodStartDateAfter) {
+      (filter.periodStartDate as Record<string, Date>).$gte = options.periodStartDateAfter;
+    }
+    if (options.periodStartDateBefore) {
+      (filter.periodStartDate as Record<string, Date>).$lt = options.periodStartDateBefore;
+    }
+  }
+
+  return filter;
+}
+
+export async function upsertMemoryDiarySummary(
+  input: MemoryDiarySummaryWriteInput,
+): Promise<IMemoryDiarySummary> {
+  const now = new Date();
+  const model = await getMemoryDiarySummaryModel();
+
+  const summary = await model
+    .findOneAndUpdate(
+      {
+        subject: input.subject,
+        period: input.period,
+        periodStartDate: input.periodStartDate,
+        isDev: input.isDev ?? false,
+      },
+      {
+        $set: {
+          periodEndDate: input.periodEndDate,
+          text: input.text,
+          generatedAt: now,
+          updatedAt: now,
+        },
+        $setOnInsert: {
+          subject: input.subject,
+          period: input.period,
+          periodStartDate: input.periodStartDate,
+          isDev: input.isDev ?? false,
+        },
+      },
+      {
+        new: true,
+        upsert: true,
+        setDefaultsOnInsert: true,
+      },
+    )
+    .exec();
+
+  if (!summary) {
+    throw new Error("upsertMemoryDiarySummary failed");
+  }
+
+  await syncMemoryDiarySummaryDocument(summary);
+  return summary;
+}
+
+export async function getMemoryDiarySummaries(
+  options: GetMemoryDiarySummariesOptions = {},
+): Promise<IMemoryDiarySummary[]> {
+  const filter = buildMemoryDiarySummaryFilter(options);
+  const sortDirection = options.sortDirection === "asc" ? 1 : -1;
+  const model = await getMemoryDiarySummaryModel(options.readFrom);
+
+  return await model
+    .find(filter)
+    .sort({ periodStartDate: sortDirection, updatedAt: sortDirection })
+    .skip(Math.max(0, options.skip ?? 0))
+    .limit(options.limit ?? 10)
+    .exec();
+}
+
+async function syncMemoryDiarySummaryDocument(summary: IMemoryDiarySummary): Promise<void> {
+  if (!hasSyncMongoUri()) {
+    return;
+  }
+
+  try {
+    const syncModel = await getMemoryDiarySummaryModel("sync");
+    await syncModel
+      .replaceOne(
+        {
+          subject: summary.subject,
+          period: summary.period,
+          periodStartDate: summary.periodStartDate,
+          isDev: summary.isDev,
+        },
+        {
+          _id: summary._id,
+          subject: summary.subject,
+          period: summary.period,
+          periodStartDate: summary.periodStartDate,
+          periodEndDate: summary.periodEndDate,
+          text: summary.text,
+          generatedAt: summary.generatedAt,
+          updatedAt: summary.updatedAt,
+          isDev: summary.isDev,
+        },
+        { upsert: true },
+      )
+      .exec();
+  } catch (error) {
+    console.error(`Sync Mongo write failed: memory_diary_summary ${summary._id}`, error);
+  }
+}

--- a/packages/utils/src/db/schema/memory-diary-summary.schema.ts
+++ b/packages/utils/src/db/schema/memory-diary-summary.schema.ts
@@ -1,0 +1,45 @@
+import mongoose, { type Document, Schema } from "mongoose";
+import type { MemoryDiarySummaryPeriod } from "../../memory/diary";
+import { getMongoConnection, type MongoReadSource } from "../connect";
+
+export interface IMemoryDiarySummary extends Document {
+  subject: string;
+  period: MemoryDiarySummaryPeriod;
+  periodStartDate: Date;
+  periodEndDate: Date;
+  text: string;
+  generatedAt: Date;
+  updatedAt: Date;
+  isDev: boolean;
+}
+
+export const MemoryDiarySummarySchema = new Schema<IMemoryDiarySummary>(
+  {
+    subject: { type: String, required: true, index: true },
+    period: { type: String, required: true, enum: ["week", "month", "year"], index: true },
+    periodStartDate: { type: Date, required: true, index: true },
+    periodEndDate: { type: Date, required: true },
+    text: { type: String, required: true },
+    generatedAt: { type: Date, required: true },
+    updatedAt: { type: Date, required: true },
+    isDev: { type: Boolean, required: true, default: false, index: true },
+  },
+  {
+    collection: "memory_diary_summary",
+  },
+);
+
+MemoryDiarySummarySchema.index(
+  { subject: 1, period: 1, periodStartDate: 1, isDev: 1 },
+  { unique: true },
+);
+
+export async function getMemoryDiarySummaryModel(
+  source: MongoReadSource = "primary",
+): Promise<mongoose.Model<IMemoryDiarySummary>> {
+  const connection = await getMongoConnection(source);
+  return (
+    (connection.models.MemoryDiarySummary as mongoose.Model<IMemoryDiarySummary> | undefined) ??
+    connection.model<IMemoryDiarySummary>("MemoryDiarySummary", MemoryDiarySummarySchema)
+  );
+}

--- a/packages/utils/src/llm/tools/memory-search.ts
+++ b/packages/utils/src/llm/tools/memory-search.ts
@@ -20,6 +20,10 @@ const diarySearchInputSchema = z.strictObject({
   limit: z.number().int().min(1).max(20).optional().describe("返回结果上限，默认 2。"),
   startDate: z.string().optional().describe("开始日期，格式 YYYY-MM-DD。"),
   endDate: z.string().optional().describe("结束日期，格式 YYYY-MM-DD。"),
+  period: z
+    .enum(["day", "week", "month", "year"])
+    .optional()
+    .describe("查询粒度。day 查询每日 Diary；week/month/year 查询对应周期总结。默认 day。"),
 });
 
 export const todayEventSearchTool: Tool = {
@@ -50,6 +54,7 @@ export const diarySearchTool: Tool = {
   execute: async (input) => {
     const result = await searchDiaries({
       limit: input.limit,
+      period: input.period,
       startTime: input.startDate ? `${input.startDate} 00:00:00` : undefined,
       endTime: input.endDate ? `${input.endDate} 23:59:59` : undefined,
     });

--- a/packages/utils/src/memory/diary.ts
+++ b/packages/utils/src/memory/diary.ts
@@ -14,7 +14,50 @@ export interface MemoryDiaryEntry {
   isDev?: boolean;
 }
 
+export type MemoryDiarySummaryPeriod = "week" | "month" | "year";
+
+export interface MemoryDiarySummaryEntry {
+  subject: string;
+  period: MemoryDiarySummaryPeriod;
+  periodStartDate: Date;
+  periodEndDate: Date;
+  text: string;
+  generatedAt?: Date;
+  updatedAt?: Date;
+  isDev?: boolean;
+}
+
 /**
  * 当前项目中默认的日记主体。
  */
 export const DEFAULT_DIARY_SUBJECT = "ゆいじゅ";
+
+export function resolveDiarySummaryPeriodRange(input: {
+  period: MemoryDiarySummaryPeriod;
+  date: Date;
+}): {
+  periodStartDate: Date;
+  periodEndDate: Date;
+} {
+  const date = new Date(input.date);
+  const startOfDay = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+  if (input.period === "week") {
+    const mondayOffset = (startOfDay.getDay() + 6) % 7;
+    const periodStartDate = new Date(startOfDay);
+    periodStartDate.setDate(startOfDay.getDate() - mondayOffset);
+    const periodEndDate = new Date(periodStartDate);
+    periodEndDate.setDate(periodStartDate.getDate() + 7);
+    return { periodStartDate, periodEndDate };
+  }
+
+  if (input.period === "month") {
+    const periodStartDate = new Date(startOfDay.getFullYear(), startOfDay.getMonth(), 1);
+    const periodEndDate = new Date(startOfDay.getFullYear(), startOfDay.getMonth() + 1, 1);
+    return { periodStartDate, periodEndDate };
+  }
+
+  const periodStartDate = new Date(startOfDay.getFullYear(), 0, 1);
+  const periodEndDate = new Date(startOfDay.getFullYear() + 1, 0, 1);
+  return { periodStartDate, periodEndDate };
+}

--- a/packages/utils/src/memory/person-memory/index.ts
+++ b/packages/utils/src/memory/person-memory/index.ts
@@ -7,4 +7,4 @@ export type {
   PersonMemoryUpdateInput,
   PersonMemoryUpdateResult,
 } from "./types";
-export { updatePersonMemory } from "./update";
+export { applyPersonMemoryProposalToDocument, updatePersonMemory } from "./update";

--- a/packages/utils/src/memory/person-memory/update.ts
+++ b/packages/utils/src/memory/person-memory/update.ts
@@ -110,7 +110,7 @@ export async function updatePersonMemory(
     };
   }
 
-  const nextMemory = applyProposalToDocument({
+  const nextMemory = applyPersonMemoryProposalToDocument({
     nickname: input.nickname,
     existingMemory,
     proposal,
@@ -211,7 +211,7 @@ function reviewPersonMemoryProposalTool(input: Omit<PersonMemoryReviewContext, "
   });
 }
 
-function applyProposalToDocument(input: {
+export function applyPersonMemoryProposalToDocument(input: {
   nickname: string;
   existingMemory: PersonMemoryDocument | null;
   proposal: PersonMemoryProposal;

--- a/packages/utils/src/memory/query-router.ts
+++ b/packages/utils/src/memory/query-router.ts
@@ -1,9 +1,9 @@
 import dayjs from "dayjs";
 import { SUBJECT_NAME } from "../constants";
-import { getMemoryDiaries, getRecentMemoryEpisodes } from "../db";
+import { getMemoryDiaries, getMemoryDiarySummaries, getRecentMemoryEpisodes } from "../db";
 import { isDev } from "../env";
 import { formatProjectTime, parseProjectTime } from "../time";
-import { DEFAULT_DIARY_SUBJECT } from "./diary";
+import { DEFAULT_DIARY_SUBJECT, type MemoryDiarySummaryPeriod } from "./diary";
 
 export type MemoryQueryTimeSort = "asc" | "desc";
 
@@ -18,6 +18,7 @@ export interface DiarySearchInput {
   startTime?: string;
   endTime?: string;
   timeSort?: MemoryQueryTimeSort;
+  period?: "day" | MemoryDiarySummaryPeriod;
   /**
    * 默认2
    */
@@ -31,6 +32,7 @@ export interface EpisodeSearchResult {
 
 export interface DiarySearchResult {
   date: string;
+  period?: "day" | MemoryDiarySummaryPeriod;
   content: string;
 }
 
@@ -75,6 +77,7 @@ export async function searchEpisodes(input: EpisodeSearchInput): Promise<Episode
 export async function searchDiaries(input: DiarySearchInput): Promise<DiarySearchResult[]> {
   const limit = input.limit ?? 2;
   const timeSort = input.timeSort ?? "desc";
+  const period = input.period ?? "day";
   const parsedStartTime = parseProjectTime(input.startTime?.trim() ?? "", "YYYY-MM-DD HH:mm:ss");
   const parsedEndTime = parseProjectTime(input.endTime?.trim() ?? "", "YYYY-MM-DD HH:mm:ss");
   const startDay = parsedStartTime ? dayjs(parsedStartTime).startOf("day").toDate() : undefined;
@@ -100,6 +103,24 @@ export async function searchDiaries(input: DiarySearchInput): Promise<DiarySearc
     diaryDateBefore = dayjs().startOf("day").toDate();
   }
 
+  if (period !== "day") {
+    const summaries = await getMemoryDiarySummaries({
+      limit,
+      subject: DEFAULT_DIARY_SUBJECT,
+      period,
+      isDev: isDev(),
+      sortDirection: timeSort,
+      periodStartDateAfter: diaryDateAfter,
+      periodStartDateBefore: diaryDateBefore,
+    });
+
+    return summaries.map((summary) => ({
+      date: `${formatProjectTime(summary.periodStartDate, "YYYY-MM-DD")}~${formatProjectTime(dayjs(summary.periodEndDate).subtract(1, "day").toDate(), "YYYY-MM-DD")}`,
+      period: summary.period,
+      content: summary.text,
+    }));
+  }
+
   const diaries = await getMemoryDiaries({
     limit,
     subject: DEFAULT_DIARY_SUBJECT,
@@ -111,6 +132,7 @@ export async function searchDiaries(input: DiarySearchInput): Promise<DiarySearc
 
   return diaries.map((diary) => ({
     date: formatProjectTime(diary.diaryDate, "YYYY-MM-DD"),
+    period: "day",
     content: diary.text,
   }));
 }

--- a/packages/utils/src/prompt/diary.ts
+++ b/packages/utils/src/prompt/diary.ts
@@ -6,6 +6,13 @@ export interface DiaryPromptInput {
   diaryDate: Date;
 }
 
+export interface DiarySummaryPromptInput {
+  subject: string;
+  period: "week" | "month" | "year";
+  periodStartDate: Date;
+  periodEndDate: Date;
+}
+
 /**
  * 构建少女风格日记的系统提示词。
  *
@@ -55,5 +62,36 @@ ${baseInformation}
 ## 输出要求
 - 只输出最终日记正文，不要加标题，不要加“今天的日记：”之类的前缀，不要解释你的写法。
 - 分段写，不要连在一起。
+`.trim();
+}
+
+export function buildDiarySummarySystemPrompt(input: DiarySummaryPromptInput): string {
+  const periodText = {
+    week: "这一周",
+    month: "这个月",
+    year: "这一年",
+  }[input.period];
+  const periodStartText = dayjs(input.periodStartDate).format("YYYY-MM-DD");
+  const periodEndText = dayjs(input.periodEndDate).subtract(1, "day").format("YYYY-MM-DD");
+
+  return `
+你现在要以「${input.subject}」的身份整理阶段性日记回忆。
+
+${baseInformation}
+
+## 总结任务
+请根据提供的每日 Diary，整理 ${periodStartText} 至 ${periodEndText} 的${periodText}回忆。
+
+## 写作要求
+- 必须使用第一人称，像悠酱在回头整理自己的阶段性回忆。
+- 不要写成系统报告、流水账、数据库摘要或旁白说明。
+- 要保留这一阶段最值得未来想起的人、事、地点、变化和感受。
+- 可以概括重复发生的生活节奏，但必须挂在每日 Diary 中能找到的事实上。
+- 不要编造未发生的事件、关系变化或心理活动。
+- 不要逐日罗列；请把相近主题合并成自然段。
+
+## 输出要求
+- 只输出总结正文，不要标题，不要解释写法。
+- 分段写，控制在 400 到 800 字之间。
 `.trim();
 }

--- a/packages/utils/tests/memory/diary.test.ts
+++ b/packages/utils/tests/memory/diary.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { resolveDiarySummaryPeriodRange } from "../../src/memory/diary";
+
+function toDateText(value: Date): string {
+  return [
+    value.getFullYear(),
+    String(value.getMonth() + 1).padStart(2, "0"),
+    String(value.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+describe("resolveDiarySummaryPeriodRange", () => {
+  it("会按周一到下周一解析自然周范围", () => {
+    const range = resolveDiarySummaryPeriodRange({
+      period: "week",
+      date: new Date("2026-06-24T12:00:00+08:00"),
+    });
+
+    expect(toDateText(range.periodStartDate)).toBe("2026-06-22");
+    expect(toDateText(range.periodEndDate)).toBe("2026-06-29");
+  });
+
+  it("会解析自然月范围", () => {
+    const range = resolveDiarySummaryPeriodRange({
+      period: "month",
+      date: new Date("2026-02-14T12:00:00+08:00"),
+    });
+
+    expect(toDateText(range.periodStartDate)).toBe("2026-02-01");
+    expect(toDateText(range.periodEndDate)).toBe("2026-03-01");
+  });
+
+  it("会解析自然年范围", () => {
+    const range = resolveDiarySummaryPeriodRange({
+      period: "year",
+      date: new Date("2026-06-14T12:00:00+08:00"),
+    });
+
+    expect(toDateText(range.periodStartDate)).toBe("2026-01-01");
+    expect(toDateText(range.periodEndDate)).toBe("2027-01-01");
+  });
+});

--- a/packages/utils/tests/memory/person-memory.test.ts
+++ b/packages/utils/tests/memory/person-memory.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { PersonMemoryFormatError } from "../../src/memory/person-memory/format";
+import { parsePersonMemoryJson } from "../../src/memory/person-memory/storage";
+import {
+  EMPTY_PERSON_MEMORY_SECTION,
+  PERSON_MEMORY_SECTION_KEYS,
+  type PersonMemoryDocument,
+} from "../../src/memory/person-memory/types";
+import { applyPersonMemoryProposalToDocument } from "../../src/memory/person-memory/update";
+
+function buildMemoryDocument(overrides: Partial<PersonMemoryDocument> = {}): PersonMemoryDocument {
+  return {
+    nickname: "猫羽芽",
+    lastUpdatedAt: "2026-06-22T12:00:00+08:00",
+    sections: {
+      称呼: "猫羽芽",
+      喜好: "喜欢画画。",
+      雷区: EMPTY_PERSON_MEMORY_SECTION,
+      最近在忙什么: "2026-06-20：在整理画稿。",
+      悠酱对她的态度: "觉得她说话很温和。",
+      最近一次值得记住的互动: "2026-06-20：她给悠酱看了新画。",
+      其他补充: EMPTY_PERSON_MEMORY_SECTION,
+    },
+    ...overrides,
+  };
+}
+
+describe("person memory storage", () => {
+  it("会解析并规范化合法人物记忆文件", () => {
+    const memory = parsePersonMemoryJson(
+      JSON.stringify({
+        ...buildMemoryDocument(),
+        sections: {
+          ...buildMemoryDocument().sections,
+          称呼: "  猫羽芽  ",
+          其他补充: "  （暂无）  ",
+        },
+      }),
+    );
+
+    expect(memory.nickname).toBe("猫羽芽");
+    expect(memory.sections.称呼).toBe("猫羽芽");
+    expect(memory.sections.其他补充).toBe(EMPTY_PERSON_MEMORY_SECTION);
+  });
+
+  it("会拒绝缺少固定 section 的人物记忆文件", () => {
+    const document = buildMemoryDocument();
+    const { 称呼, ...sectionsWithoutNickname } = document.sections;
+
+    expect(() =>
+      parsePersonMemoryJson(
+        JSON.stringify({
+          ...document,
+          sections: sectionsWithoutNickname,
+        }),
+      ),
+    ).toThrow(PersonMemoryFormatError);
+    expect(称呼).toBe("猫羽芽");
+  });
+
+  it("会拒绝列表格式的人物记忆字段", () => {
+    const document = buildMemoryDocument({
+      sections: {
+        ...buildMemoryDocument().sections,
+        喜好: "- 喜欢画画",
+      },
+    });
+
+    expect(() => parsePersonMemoryJson(JSON.stringify(document))).toThrow(PersonMemoryFormatError);
+  });
+});
+
+describe("person memory proposal applying", () => {
+  it("会基于空旧记忆创建完整 section 对象", () => {
+    const memory = applyPersonMemoryProposalToDocument({
+      nickname: "猫羽芽",
+      existingMemory: null,
+      proposal: {
+        shouldUpdate: true,
+        changes: [
+          {
+            section: "称呼",
+            content: "猫羽芽",
+            reason: "她在本次互动中被明确称为猫羽芽。",
+          },
+        ],
+      },
+    });
+
+    expect(memory.nickname).toBe("猫羽芽");
+    expect(memory.sections.称呼).toBe("猫羽芽");
+    for (const section of PERSON_MEMORY_SECTION_KEYS.filter((section) => section !== "称呼")) {
+      expect(memory.sections[section]).toBe(EMPTY_PERSON_MEMORY_SECTION);
+    }
+  });
+
+  it("只覆盖 proposal 指定的 section，并保留旧记忆其他字段", () => {
+    const existingMemory = buildMemoryDocument();
+    const memory = applyPersonMemoryProposalToDocument({
+      nickname: "猫羽芽",
+      existingMemory,
+      proposal: {
+        shouldUpdate: true,
+        changes: [
+          {
+            section: "最近在忙什么",
+            content: "2026-06-22：在准备新的角色草图。",
+            reason: "她明确说了今天的安排。",
+          },
+        ],
+      },
+    });
+
+    expect(memory.sections.最近在忙什么).toBe("2026-06-22：在准备新的角色草图。");
+    expect(memory.sections.喜好).toBe(existingMemory.sections.喜好);
+    expect(memory.sections.悠酱对她的态度).toBe(existingMemory.sections.悠酱对她的态度);
+  });
+
+  it("会拒绝 proposal 写入列表格式 section", () => {
+    expect(() =>
+      applyPersonMemoryProposalToDocument({
+        nickname: "猫羽芽",
+        existingMemory: buildMemoryDocument(),
+        proposal: {
+          shouldUpdate: true,
+          changes: [
+            {
+              section: "喜好",
+              content: "- 喜欢画画",
+              reason: "测试非法格式。",
+            },
+          ],
+        },
+      }),
+    ).toThrow(PersonMemoryFormatError);
+  });
+});

--- a/packages/utils/vite.config.ts
+++ b/packages/utils/vite.config.ts
@@ -1,0 +1,6 @@
+import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+});

--- a/packages/world/src/memory/diary/generator.ts
+++ b/packages/world/src/memory/diary/generator.ts
@@ -1,13 +1,18 @@
 import {
+  buildDiarySummarySystemPrompt,
   buildDiarySystemPrompt,
   DEFAULT_DIARY_SUBJECT,
   type DiarySummaryMaterial,
   flashModel,
+  getMemoryDiaries,
   getRecentMemoryEpisodes,
   type IMemoryEpisode,
+  type MemoryDiarySummaryPeriod,
+  resolveDiarySummaryPeriodRange,
   SUBJECT_NAME,
   summarizeConversationDiaryMaterials,
   upsertMemoryDiary,
+  upsertMemoryDiarySummary,
 } from "@yuiju/utils";
 import { generateText } from "ai";
 import dayjs from "dayjs";
@@ -52,6 +57,40 @@ async function writeDiaryText(input: {
           type: item.type,
           happenedAt: item.happenedAt,
           content: item.content,
+        })),
+      ),
+    ].join("\n"),
+  });
+
+  return result.text.trim();
+}
+
+async function writeDiarySummaryText(input: {
+  subject: string;
+  period: MemoryDiarySummaryPeriod;
+  periodStartDate: Date;
+  periodEndDate: Date;
+  dailyDiaries: { diaryDate: Date; text: string }[];
+}): Promise<string> {
+  const result = await generateText({
+    model: flashModel,
+    providerOptions: {
+      flash: {
+        enable_thinking: false,
+      },
+    },
+    system: buildDiarySummarySystemPrompt({
+      subject: input.subject,
+      period: input.period,
+      periodStartDate: input.periodStartDate,
+      periodEndDate: input.periodEndDate,
+    }),
+    prompt: [
+      "以下是这一阶段已经生成的每日 Diary，请严格基于这些内容整理阶段性回忆。",
+      JSON.stringify(
+        input.dailyDiaries.map((diary) => ({
+          diaryDate: dayjs(diary.diaryDate).format("YYYY-MM-DD"),
+          text: diary.text,
         })),
       ),
     ].join("\n"),
@@ -182,10 +221,73 @@ export async function generateDiaryForDate(input: GenerateDiaryForDateInput): Pr
     isDev: input.isDev,
   });
 
+  await refreshDiarySummariesForDate({
+    subject,
+    diaryDate: input.diaryDate,
+    isDev: input.isDev,
+  });
+
   logger.info("[generateDiaryForDate] diary generated", {
     subject,
     diaryDate: dayjs(input.diaryDate).format("YYYY-MM-DD"),
   });
 
   return true;
+}
+
+export async function refreshDiarySummariesForDate(input: {
+  subject?: string;
+  diaryDate: Date;
+  isDev: boolean;
+}): Promise<void> {
+  const subject = input.subject ?? DEFAULT_DIARY_SUBJECT;
+  const periods: MemoryDiarySummaryPeriod[] = ["week", "month", "year"];
+
+  for (const period of periods) {
+    const { periodStartDate, periodEndDate } = resolveDiarySummaryPeriodRange({
+      period,
+      date: input.diaryDate,
+    });
+    const dailyDiaries = await getMemoryDiaries({
+      subject,
+      isDev: input.isDev,
+      diaryDateAfter: periodStartDate,
+      diaryDateBefore: periodEndDate,
+      sortDirection: "asc",
+      limit: 400,
+    });
+
+    if (dailyDiaries.length === 0) {
+      continue;
+    }
+
+    const summaryText = await writeDiarySummaryText({
+      subject,
+      period,
+      periodStartDate,
+      periodEndDate,
+      dailyDiaries: dailyDiaries.map((diary) => ({
+        diaryDate: diary.diaryDate,
+        text: diary.text,
+      })),
+    });
+
+    if (!summaryText.trim()) {
+      logger.warn("[refreshDiarySummariesForDate] generated empty diary summary", {
+        subject,
+        period,
+        diaryDate: dayjs(input.diaryDate).format("YYYY-MM-DD"),
+      });
+      continue;
+    }
+
+    await upsertMemoryDiarySummary({
+      subject,
+      period,
+      periodStartDate,
+      periodEndDate,
+      text: summaryText,
+      isDev: input.isDev,
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- Add Vitest support for @yuiju/utils and deterministic person memory tests.
- Cover person memory JSON parsing, fixed section validation, proposal application, and invalid section formats.
- Add a non-destructive memory_diary_summary Mongo collection for week/month/year diary summaries.
- Refresh week/month/year summaries after daily diary generation.
- Extend diarySearch with period: day | week | month | year.

## Issue
Fixes #81

## Self-check
- User file memory optimization is covered with deterministic tests for the current file-memory contract.
- Diary weekly/monthly/yearly layered summaries are generated and searchable through the tool layer.
- Existing daily diary storage remains unchanged; summary data is stored separately.

## Verification
- pnpm run format:write passed.
- pnpm run lint passed.
- pnpm run type-check passed.
- pnpm run test:utils passed, 9 tests.
- pnpm run test:world failed because local Redis was not reachable; the failure happens in existing worldState.reset() Redis setup, not in a new assertion.