### PR TITLE
fix: 为海岸往返与上课预留资源门槛，防止不可逆死锁

### DIFF
--- a/packages/world/src/action/business-district/train-station.ts
+++ b/packages/world/src/action/business-district/train-station.ts
@@ -100,14 +100,15 @@ export const trainStationAction: ActionMetadata[] = [
   },
   {
     action: ActionId.Take_Train_To_Coast_From_Train_Station,
-    description: "从羽浦站乘电车前往月汐海岸。[金币-3][体力-7][饱腹-5][耗时15分钟]",
+    description: `从羽浦站乘电车前往月汐海岸。[金币-3][体力-7][饱腹-5][需金币≥${TRAIN_FARE * 2}][耗时15分钟]`,
     proactiveShare: {
       enabled: true,
     },
     precondition(context) {
       return allTrue([
         () => isAtTrainStation(context),
-        () => context.characterStateData.money >= TRAIN_FARE,
+        // 预留往返车费：离开海岸的唯一方式是乘电车返回，同样需要 TRAIN_FARE
+        () => context.characterStateData.money >= TRAIN_FARE * 2,
       ]);
     },
     async executor(context) {

--- a/packages/world/src/action/school/campus.ts
+++ b/packages/world/src/action/school/campus.ts
@@ -20,11 +20,14 @@ function isAtSchoolCampus(context: ActionContext) {
   );
 }
 
+/** 上课消耗 12 体力，且下课后「从学校回家」要求体力 ≥ 10，预留两者之和 */
+const STUDY_REQUIRED_STAMINA = 22;
+
 export const schoolAction: ActionMetadata[] = [
   {
     // TODO：逻辑优化，上课时间应该是固定的时间段，而不是随时可以上课
     action: ActionId.Study_At_School,
-    description: "在星见丘高校上课。[体力-12][饱腹-12][心情-5][耗时动态]",
+    description: `在星见丘高校上课。[体力-12][饱腹-12][心情-5][需体力≥${STUDY_REQUIRED_STAMINA}][耗时动态]`,
     proactiveShare: {
       enabled: true,
     },
@@ -37,6 +40,7 @@ export const schoolAction: ActionMetadata[] = [
           return (hour >= 9 && hour < 12) || (hour >= 14 && hour < 16);
         },
         isWeekday(context),
+        context.characterStateData.stamina >= STUDY_REQUIRED_STAMINA,
       ]);
     },
     async executor(context) {
@@ -94,7 +98,7 @@ export const schoolAction: ActionMetadata[] = [
   },
   {
     action: ActionId.Go_Home_From_School,
-    description: "从星见丘高校回家。[体力-7][饱腹-5][耗时20分钟]",
+    description: "从星见丘高校回家。[体力-7][饱腹-5][仅限下午][需体力≥10][耗时20分钟]",
     proactiveShare: {
       enabled: true,
     },


### PR DESCRIPTION
Closes #106

## 问题

对应 issue #106：角色可因体力/金钱耗尽陷入**不可逆死锁**——离开当前地点的所有动作 precondition 失效，候选仅剩零恢复的「发呆」，生活循环（回家→睡觉→日记）完全中断。两条死锁路径：

- **海岸（金钱型）**：余额恰好 3 时可乘电车进入月汐海岸（单程 3），到达后余额归零；离开海岸的唯一动作「乘电车返回」需要 3，永久困死。
- **学校（体力型）**：上课不检查体力，体力低于 22 时选课，结算扣 12 后体力归零（clamp 至 0）；「从学校回家」要求体力 ≥ 10、「去商业区」要求 ≥ 5，全部失效且无恢复途径，永久困死。

根因是 precondition 门槛对决策层不可见：description 只标注执行代价（[体力-12]），LLM 无法预判选完后选项会静默消失。

## 修改内容

按 issue 修复方向第 1+2 层实施（第 3 层 Idle 改造涉及行为经济设计，适合单独 PR）：

| 文件 | 修改 |
|------|------|
| `packages/world/src/action/business-district/train-station.ts` | 进海岸门槛从 `money >= TRAIN_FARE` 提高为 `money >= TRAIN_FARE * 2`（预留往返车费），description 标注 `[需金币≥6]` |
| `packages/world/src/action/school/campus.ts` | 上课 precondition 新增 `stamina >= STUDY_REQUIRED_STAMINA(22)`（上课消耗 12 + 回家门槛 10），description 标注 `[需体力≥22]`；「从学校回家」description 标注 `[仅限下午][需体力≥10]` |

安全边际编码进 precondition 后，死锁在数学上被排除，不依赖 LLM 自觉；description 标注门槛给模型规划的机会，减少进入边缘状态的频率。

## 验证

- **precondition 边界用例 12 项全部通过**（临时脚本直测 precondition 函数，验证后已删除）：
  - 海岸：余额 3/5 拒绝（旧门槛下 3 是死锁入口）；余额 6（恰为往返）放行；余额 100 放行；不在羽浦站拒绝
  - 学校：体力 15/21 拒绝（旧门槛下 15 是死锁入口）；体力 22 放行；体力 22 上完课剩 10，恰好满足回家门槛
  - 回归：周末上课仍拒绝、体力 100 周三上课仍允许、下午回家仍允许——原有约束无误伤
- `biome lint` 通过；`tsc --noEmit`（world/message/utils 三包）通过（pre-commit 钩子全量执行）

## 影响说明

- 仅收紧进入门槛（余额 <6 不能去海岸、体力 <22 不能上课），对正常数值区间的行为无任何变化
- 角色行为变化：低资源时 LLM 候选列表中不再出现会困死自己的选项，转而选择打工/休息等安全行为——这正是修复目标