### PR TITLE
feat: Idle 升级为分档恢复的休息动作（issue #106 第 3 层兜底）

### DIFF
--- a/packages/world/src/action/anywhere.ts
+++ b/packages/world/src/action/anywhere.ts
@@ -17,6 +17,45 @@ import {
 import { logger } from "@/utils/logger";
 import { resolveFoodRecoveryPerUnit } from "../utils/food-utils";
 
+interface IdleTier {
+  durationMin: number;
+  staminaGain: number;
+  moodGain: number;
+}
+
+/**
+ * 发呆/休息的预设档位。
+ *
+ * 说明：
+ * - 数值刻意低于「待在家」（60min 体力+20/心情基础+5），保证家仍是首选休息地；
+ * - 体力恢复是全系统唯一不依赖地点的来源，承担"任何地点被困时的兜底自救"职责；
+ * - 心情走 recoverMood 递减结算，档位值仅为基础值。
+ */
+const IDLE_TIERS: IdleTier[] = [
+  { durationMin: 10, staminaGain: 2, moodGain: 1 },
+  { durationMin: 30, staminaGain: 5, moodGain: 2 },
+  { durationMin: 60, staminaGain: 8, moodGain: 3 },
+  { durationMin: 120, staminaGain: 12, moodGain: 4 },
+];
+
+const DEFAULT_IDLE_TIER = IDLE_TIERS[0];
+
+/**
+ * 将 LLM 给出的任意时长收敛到发呆支持的预设档位。
+ *
+ * 规则：未给出时长取默认档；非档位值取不小于该时长的最小档；超过最大值钳制到 120 分钟档。
+ */
+function resolveIdleTier(llmDurationMin?: number): IdleTier {
+  if (!llmDurationMin || llmDurationMin <= 0) {
+    return DEFAULT_IDLE_TIER;
+  }
+
+  return (
+    IDLE_TIERS.find((tier) => llmDurationMin <= tier.durationMin) ??
+    IDLE_TIERS[IDLE_TIERS.length - 1]
+  );
+}
+
 function getAvailableFoodOptions(context: ActionContext): ChoiceOption[] {
   const inventory = context.characterStateData.inventory || [];
   const availableFood = inventory.filter(
@@ -35,18 +74,48 @@ function getAvailableFoodOptions(context: ActionContext): ChoiceOption[] {
 export const anywhereAction: ActionMetadata[] = [
   {
     action: ActionId.Idle,
-    description: "休息等待，可以在任何地点进行。[耗时需要给出]",
+    description:
+      "休息等待，可以在任何地点进行，按 10/30/60/120 分钟四档安排时长，时间越久恢复越多，但恢复效果不如在家休息。[体力+2~+12][心情基础恢复+1~+4][耗时需要给出]",
     proactiveShare: {
       enabled: true,
     },
     precondition(_context) {
       return true;
     },
-    async executor(context) {
+    async executor(context, selectedAction) {
+      const selectedTier = resolveIdleTier(selectedAction?.durationMinute);
       await context.characterState.setAction(ActionId.Idle);
+
+      return {
+        executionResult: `原地休息，预计${selectedTier.durationMin}分钟`,
+        startContext: {
+          durationMin: selectedTier.durationMin,
+          staminaGain: selectedTier.staminaGain,
+          moodGain: selectedTier.moodGain,
+        },
+      };
     },
     async durationMin(_context, selectedAction) {
-      return selectedAction?.durationMinute ?? 10;
+      return resolveIdleTier(selectedAction?.durationMinute).durationMin;
+    },
+    async completionEvent(context, runningAction) {
+      const restContext = runningAction.startContext as IdleTier;
+
+      await context.characterState.changeStamina(restContext.staminaGain);
+      const actualMoodGain = await context.characterState.recoverMood(restContext.moodGain);
+      const location = context.characterStateData.location;
+      const locationText = `${location.major}${location.minor ? `-${location.minor}` : ""}`;
+
+      context.runtimeState.actionSummaryText = `悠酱在「${locationText}」休息了${restContext.durationMin}分钟，体力恢复了${restContext.staminaGain}点，心情提升了${actualMoodGain}点`;
+
+      return {
+        completionContext: {
+          durationMin: restContext.durationMin,
+          staminaGain: restContext.staminaGain,
+          moodGain: restContext.moodGain,
+          actualMoodGain,
+        },
+      };
     },
   },
   {

--- a/packages/world/src/memory/episode-builder.ts
+++ b/packages/world/src/memory/episode-builder.ts
@@ -6,7 +6,7 @@ import type {
   RunningActionState,
   WeatherSnapshot,
 } from "@yuiju/utils";
-import { ActionId, SUBJECT_NAME } from "@yuiju/utils";
+import { type ActionId, SUBJECT_NAME } from "@yuiju/utils";
 
 export interface BuildBehaviorEpisodeInput {
   context: ActionContext;
@@ -46,10 +46,6 @@ interface WeatherChangedEpisodePayload {
 export function buildRunningBehaviorEpisode(
   input: BuildBehaviorEpisodeInput,
 ): MemoryEpisode<BehaviorEpisodePayload> | null {
-  if (input.selectedAction.action === ActionId.Idle) {
-    return null;
-  }
-
   return {
     source: "world_tick",
     type: "behavior",


### PR DESCRIPTION
关联 #106（与 #107 互补：#107 是第 1+2 层根治，本 PR 是第 3 层兜底）

## 问题

issue #106 的第三条修复方向：`Idle`（发呆）作为全系统唯一 precondition 恒真的兜底动作，却是**零恢复、无结算、不可见**的：

- **零恢复**：executor 仅 `setAction`，无 completionEvent——死锁场景下候选列表的最后一项没有任何自救能力；
- **心情死循环（实测）**：2026-08-17 13:11–13:51，角色在结灯神社连续 5 次选择发呆，理由均为"心情还没完全沉下来，再坐一会儿"，心情 65 全程无变化——LLM 以为安静待着在恢复心情，实际数值纹丝不动；
- **决策盲区**：`episode-builder` 对 Idle 短路不写 episode，发呆不进决策历史/日记/行为轨迹，LLM 无法看到"我已经连续发呆 N 次"，循环无法被自知打破。

## 修改内容

| 文件 | 修改 |
|------|------|
| `packages/world/src/action/anywhere.ts` | 新增 `IDLE_TIERS` 四档 + `resolveIdleTier` 收敛函数（复用南风公园 `PARK_WALK_TIERS` 范式）；executor 解析档位存 startContext；新增 completionEvent 结算；description 标注档位信息 |
| `packages/world/src/memory/episode-builder.ts` | 移除对 Idle 的 episode 短路（3 行），发呆进入标准两阶段生命周期 |

**档位表**：

| 时长 | 体力 | 心情（基础值，走 recoverMood 递减） |
|------|:---:|:---:|
| 10min | +2 | +1 |
| 30min | +5 | +2 |
| 60min | +8 | +3 |
| 120min | +12 | +4 |

**数值设计约束**（防止破坏既有行为经济）：

- 严格低于「待在家」（60min 体力+20/心情基础+5）——家仍是首选休息地；
- 心情单维低于公园散步（+2~+15）与神社参拜（+4）——专项场景仍优于发呆；
- 发呆的差异化价值 = **体力恢复的唯一"任意地点"来源**，即兜底自救职责：体力 0 被困任意地点时，约 2 小时可恢复至满足"去商业区 ≥5"门槛，死局降级为绕路。

## 有意的行为变化（请维护者确认）

1. 决策历史的最近 10 条行为名额会被发呆占据——换来 LLM 能看到连续发呆并主动打破循环（这正是修复目标）；
2. 日记素材与 Web 行为轨迹将出现「休息了N分钟」条目——与 `Sleep_For_A_Little`、短参拜等既有低信息条目风格一致。

若认为日记噪音不可接受，可退回仅保留 precondition/precondition 文件中的档位恢复（去掉 episode-builder 改动），但决策盲区问题将保留，欢迎讨论。

## 验证

- 边界用例 **20 项全部通过**（临时脚本直测，验证后已删除）：
  - 档位收敛：未给时长→10 档；10/15/45/999→10/30/60/120（向上取档、钳制）
  - executor：startContext 正确写入档位值
  - completionEvent：changeStamina/recoverMood 按档位调用，completionContext 含递减后实际心情恢复
  - episode：Idle 不再返回 null、status=running；非 Idle 动作行为无回归
  - durationMin async 化后档位收敛行为复验不变
- `biome lint` 通过；`tsc --noEmit`（world/message/utils 三包）通过（pre-commit 钩子全量执行）

## 与 #107 的关系

- 改动文件无交集（#107：train-station/campus；本 PR：anywhere/episode-builder），无合并冲突
- #107 在数学上排除已知死锁入口；本 PR 提供纵深防御——任何未来新增场景的 precondition 疏漏不再直接等于不可逆死局