### PR TITLE
test(world): 为软锁修复补充 Action 不变量回归测试

### DIFF
--- a/packages/world/src/action/softlock-invariants.test.ts
+++ b/packages/world/src/action/softlock-invariants.test.ts
@@ -1,0 +1,192 @@
+import dayjs from "dayjs";
+import { describe, expect, it, vi } from "vitest";
+import type { ActionContext, ActionMetadata } from "@yuiju/utils/types/action";
+import { ActionId } from "@yuiju/utils/types/action";
+import {
+  BusinessDistrictSubScene,
+  HomeSubScene,
+  MajorScene,
+  SchoolSubScene,
+} from "@yuiju/utils/types/state";
+import { anywhereAction } from "./anywhere";
+import { trainStationAction } from "./business-district/train-station";
+import { schoolAction } from "./school/campus";
+
+vi.mock("@/llm/agent/anywhere", () => ({ chooseFoodAgent: vi.fn() }));
+vi.mock("@/llm/agent/phone", () => ({
+  generatePhoneUsePlanFromReason: vi.fn(),
+  runPhoneApplication: vi.fn(),
+}));
+vi.mock("@/llm/agent/random-event", () => ({
+  buildActionRandomEventDescription: vi.fn(),
+  buildMoodChangeDescription: vi.fn(),
+  generateActionRandomEvent: vi.fn(),
+}));
+vi.mock("@/utils/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+function getAction(actions: ActionMetadata[], actionId: ActionId): ActionMetadata {
+  return actions.find((action) => action.action === actionId)!;
+}
+
+function createContext(input: {
+  major: MajorScene;
+  minor: BusinessDistrictSubScene | HomeSubScene | SchoolSubScene;
+  money?: number;
+  stamina?: number;
+  time?: string;
+}) {
+  const setAction = vi.fn();
+  const changeStamina = vi.fn();
+  const recoverMood = vi.fn().mockResolvedValue(3);
+
+  const context = {
+    characterState: {
+      setAction,
+      changeStamina,
+      recoverMood,
+    },
+    characterStateData: {
+      location: {
+        major: input.major,
+        minor: input.minor,
+      },
+      money: input.money ?? 0,
+      stamina: input.stamina ?? 0,
+    },
+    worldState: {
+      time: dayjs(input.time ?? "2026-08-17T09:30:00"),
+    },
+    runtimeState: {
+      actionStartedAt: new Date("2026-08-17T01:30:00.000Z"),
+    },
+  } as unknown as ActionContext;
+
+  return { context, setAction, changeStamina, recoverMood };
+}
+
+describe("world action softlock invariants", () => {
+  const idleAction = getAction(anywhereAction, ActionId.Idle);
+  const takeTrainToCoastAction = getAction(
+    trainStationAction,
+    ActionId.Take_Train_To_Coast_From_Train_Station,
+  );
+  const studyAtSchoolAction = getAction(schoolAction, ActionId.Study_At_School);
+
+  it("keeps Idle available at any location", async () => {
+    const { context } = createContext({
+      major: MajorScene.Home,
+      minor: HomeSubScene.House,
+    });
+
+    expect(await idleAction.precondition(context)).toBe(true);
+  });
+
+  it.each([
+    [undefined, 10],
+    [1, 10],
+    [10, 10],
+    [11, 30],
+    [31, 60],
+    [61, 120],
+    [121, 120],
+  ])("maps Idle duration %s to the %s minute tier", async (durationMinute, expectedDuration) => {
+    const { context } = createContext({
+      major: MajorScene.Home,
+      minor: HomeSubScene.House,
+    });
+    const resolveDuration = idleAction.durationMin as Exclude<
+      ActionMetadata["durationMin"],
+      number
+    >;
+
+    await expect(
+      resolveDuration(context, {
+        action: ActionId.Idle,
+        reason: "恢复体力",
+        durationMinute,
+      }),
+    ).resolves.toBe(expectedDuration);
+  });
+
+  it("settles the selected Idle tier into character state and the action summary", async () => {
+    const { context, setAction, changeStamina, recoverMood } = createContext({
+      major: MajorScene.Home,
+      minor: HomeSubScene.House,
+    });
+
+    const startResult = await idleAction.executor(context, {
+      action: ActionId.Idle,
+      reason: "恢复体力",
+      durationMinute: 31,
+    });
+    const completionResult = await idleAction.completionEvent!(context, {
+      startContext: startResult?.startContext,
+    } as never);
+
+    expect(setAction).toHaveBeenCalledWith(ActionId.Idle);
+    expect(changeStamina).toHaveBeenCalledWith(8);
+    expect(recoverMood).toHaveBeenCalledWith(3);
+    expect(context.runtimeState.actionSummaryText).toBe(
+      "悠酱在「家-屋内」休息了60分钟，体力恢复了8点，心情提升了3点",
+    );
+    expect(completionResult).toEqual({
+      completionContext: {
+        durationMin: 60,
+        staminaGain: 8,
+        moodGain: 3,
+        actualMoodGain: 3,
+      },
+    });
+  });
+
+  it("requires enough money for both train trips before entering the coast", async () => {
+    const insufficient = createContext({
+      major: MajorScene.BusinessDistrict,
+      minor: BusinessDistrictSubScene.TrainStation,
+      money: 5,
+    });
+    const sufficient = createContext({
+      major: MajorScene.BusinessDistrict,
+      minor: BusinessDistrictSubScene.TrainStation,
+      money: 6,
+    });
+
+    expect(await takeTrainToCoastAction.precondition(insufficient.context)).toBe(false);
+    expect(await takeTrainToCoastAction.precondition(sufficient.context)).toBe(true);
+  });
+
+  it("requires the school location, class time, weekday and return-trip stamina", async () => {
+    const insufficientStamina = createContext({
+      major: MajorScene.School,
+      minor: SchoolSubScene.Campus,
+      stamina: 21,
+    });
+    const sufficientStamina = createContext({
+      major: MajorScene.School,
+      minor: SchoolSubScene.Campus,
+      stamina: 22,
+    });
+    const weekend = createContext({
+      major: MajorScene.School,
+      minor: SchoolSubScene.Campus,
+      stamina: 22,
+      time: "2026-08-22T09:30:00",
+    });
+    const outsideClassTime = createContext({
+      major: MajorScene.School,
+      minor: SchoolSubScene.Campus,
+      stamina: 22,
+      time: "2026-08-17T13:00:00",
+    });
+
+    expect(await studyAtSchoolAction.precondition(insufficientStamina.context)).toBe(false);
+    expect(await studyAtSchoolAction.precondition(sufficientStamina.context)).toBe(true);
+    expect(await studyAtSchoolAction.precondition(weekend.context)).toBe(false);
+    expect(await studyAtSchoolAction.precondition(outsideClassTime.context)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 背景

PR #107 和 #108 已分别修复海岸往返、上课资源门槛以及任意地点恢复能力，但这些防软锁约束尚未由自动化测试保护。后续调整 Action 前置条件、动态时长或完成结算时，容易在无意中破坏角色的可恢复性。

关联 Issue：#106（回归测试补充，不重复关闭已解决的问题）。

## 改动内容

- 验证 `Idle` 在任意地点保持可执行。
- 覆盖 10/30/60/120 分钟四档休息时长的边界映射。
- 验证休息完成后的体力、心情、行为摘要和结构化完成数据。
- 验证前往海岸前必须预留往返车费。
- 验证上课所需地点、工作日、上课时间和返程体力门槛。
- 使用固定工作日/周末时间，避免测试受运行机器时区影响。

## 影响范围

本 PR 仅新增 Action 回归测试，不修改运行时代码、状态结构、Prompt、配置或数据库。

## 验证

- `pnpm run lint`
- `pnpm run type-check`
- `NODE_ENV=development pnpm --filter @yuiju/world exec vitest run src/action/softlock-invariants.test.ts`
- `oxlint --deny correctness --deny suspicious packages/world/src/action/softlock-invariants.test.ts`

聚焦测试共 11 项，全部通过。