### PR TITLE
fix(web): 修复世界地图全屏自适应缩放

### DIFF
--- a/packages/web/components/game-scene/game/scenes/world-map/world-map-scene.ts
+++ b/packages/web/components/game-scene/game/scenes/world-map/world-map-scene.ts
@@ -43,13 +43,27 @@ export class WorldMapScene extends Phaser.Scene {
     this.cameras.main.fadeIn(200, 73, 50, 71);
     this.add.image(0, 0, WORLD_MAP_TEXTURE_KEY).setOrigin(0);
 
+    const resizeCamera = () => {
+      const viewportScale = Math.max(
+        this.scale.gameSize.width / WORLD_MAP_WIDTH,
+        this.scale.gameSize.height / WORLD_MAP_HEIGHT,
+      );
+      this.cameras.main.setZoom(Math.max(1, viewportScale));
+      if (viewportScale > 1) {
+        this.cameras.main.centerOn(WORLD_MAP_WIDTH / 2, WORLD_MAP_HEIGHT / 2);
+      }
+    };
+    this.scale.on(Phaser.Scale.Events.RESIZE, resizeCamera);
+
     const characterMarker = this.add
       .sprite(0, 0, CHARACTER_ATLAS.textureKey, CHARACTER_ANIMATION.worldMapMarker.frames[0])
       .setOrigin(0.5, 1)
       .setDepth(2)
       .setVisible(false);
     const updateCharacterMarker = (majorScene: MajorScene) => {
-      const region = WORLD_MAP_REGIONS.find((region) => region.majorScene === majorScene)!;
+      const region = WORLD_MAP_REGIONS.find(
+        (candidateRegion) => candidateRegion.majorScene === majorScene,
+      )!;
       characterMarker.setPosition(region.labelX, region.labelY);
       if (!characterMarker.visible) {
         characterMarker.setVisible(true).play(CHARACTER_ANIMATION.worldMapMarker.key);
@@ -59,6 +73,7 @@ export class WorldMapScene extends Phaser.Scene {
     this.game.events.on(WORLD_MAP_CHARACTER_LOCATION_CHANGE_EVENT, updateCharacterMarker);
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       this.game.events.off(WORLD_MAP_CHARACTER_LOCATION_CHANGE_EVENT, updateCharacterMarker);
+      this.scale.off(Phaser.Scale.Events.RESIZE, resizeCamera);
     });
 
     for (const region of WORLD_MAP_REGIONS) {
@@ -107,6 +122,7 @@ export class WorldMapScene extends Phaser.Scene {
 
     this.cameras.main.setBounds(0, 0, WORLD_MAP_WIDTH, WORLD_MAP_HEIGHT);
     this.cameras.main.centerOn(WORLD_MAP_WIDTH / 2, WORLD_MAP_HEIGHT / 2);
+    resizeCamera();
 
     const keyboard = this.input.keyboard!;
     this.cursorKeys = keyboard.createCursorKeys();


### PR DESCRIPTION
## 背景

全屏或大尺寸窗口下，世界地图仍按固定 1 倍缩放显示，画布扩大后地图不能覆盖可视区域，形成 Issue #110 中的全屏显示问题。

Fixes #110

## 改动内容

- 根据游戏视口与世界地图尺寸的宽高比计算相机缩放。
- 视口大于地图时使用能够覆盖画布的缩放比例，并将相机重新居中。
- 初始化场景时立即应用缩放，容器 resize 时同步更新。
- 场景 shutdown 时注销 resize 监听，避免场景重建后重复响应。
- 顺带消除同文件已有的回调参数遮蔽，不改变查找行为。

## 影响范围

本 PR 仅修改世界地图场景的相机适配逻辑，不调整地图素材、区域坐标、角色位置、移动速度或不可达提示。

## 验证

- Biome format / lint
- Oxlint correctness / suspicious
- Next route typegen
- Web TypeScript 检查
- Web 生产构建
- 全仓 TypeScript 检查
- `git diff --check`