### PR TITLE
feat(web): 将世界地图不可达提示显示在游戏画布内

### DIFF
--- a/packages/web/components/game-scene/game/scenes/world-map/world-map-ui.module.css
+++ b/packages/web/components/game-scene/game/scenes/world-map/world-map-ui.module.css
@@ -1,0 +1,20 @@
+.unavailableMessage {
+  position: absolute;
+  z-index: 4;
+  top: 12px;
+  left: 50%;
+  max-width: calc(100% - 32px);
+  padding: 9px 12px;
+  border: 2px solid #493247;
+  border-radius: 8px;
+  color: #493247;
+  background: rgb(255 249 234 / 94%);
+  box-shadow: 0 4px 12px rgb(73 50 71 / 20%);
+  font-family: "Fusion Pixel 12px Proportional", sans-serif;
+  font-size: 13px;
+  line-height: 1.4;
+  text-align: center;
+  white-space: nowrap;
+  pointer-events: none;
+  transform: translateX(-50%);
+}

--- a/packages/web/components/game-scene/game/scenes/world-map/world-map-ui.tsx
+++ b/packages/web/components/game-scene/game/scenes/world-map/world-map-ui.tsx
@@ -1,6 +1,5 @@
 import type Phaser from "phaser";
-import { useEffect } from "react";
-import { toast } from "sonner";
+import { useEffect, useRef, useState } from "react";
 import useSWR from "swr";
 import { fetchHomeSummary, HOME_SUMMARY_ENDPOINT } from "@/lib/api/home";
 import {
@@ -8,12 +7,17 @@ import {
   WORLD_MAP_MESSAGE_EVENT,
   WORLD_MAP_UNAVAILABLE_MESSAGE,
 } from "./world-map-constant";
+import styles from "./world-map-ui.module.css";
+
+const UNAVAILABLE_MESSAGE_DURATION = 2500;
 
 interface WorldMapUiProps {
   game: Phaser.Game;
 }
 
 export function WorldMapUi({ game }: WorldMapUiProps) {
+  const [unavailableMessageVisible, setUnavailableMessageVisible] = useState(false);
+  const unavailableMessageTimeoutRef = useRef<number | undefined>(undefined);
   const { data: homeData } = useSWR(HOME_SUMMARY_ENDPOINT, fetchHomeSummary, {
     refreshInterval: 30 * 1000,
   });
@@ -28,14 +32,26 @@ export function WorldMapUi({ game }: WorldMapUiProps) {
 
   useEffect(() => {
     const showUnavailableMessage = () => {
-      toast.warning(WORLD_MAP_UNAVAILABLE_MESSAGE);
+      setUnavailableMessageVisible(true);
+      if (unavailableMessageTimeoutRef.current !== undefined) {
+        window.clearTimeout(unavailableMessageTimeoutRef.current);
+      }
+      unavailableMessageTimeoutRef.current = window.setTimeout(() => {
+        setUnavailableMessageVisible(false);
+        unavailableMessageTimeoutRef.current = undefined;
+      }, UNAVAILABLE_MESSAGE_DURATION);
     };
 
     game.events.on(WORLD_MAP_MESSAGE_EVENT, showUnavailableMessage);
     return () => {
       game.events.off(WORLD_MAP_MESSAGE_EVENT, showUnavailableMessage);
+      if (unavailableMessageTimeoutRef.current !== undefined) {
+        window.clearTimeout(unavailableMessageTimeoutRef.current);
+      }
     };
   }, [game]);
 
-  return null;
+  return unavailableMessageVisible ? (
+    <output className={styles.unavailableMessage}>{WORLD_MAP_UNAVAILABLE_MESSAGE}</output>
+  ) : null;
 }


### PR DESCRIPTION
## 背景

世界地图区域暂不可进入时，当前通过页面级 toast 提示。提示脱离游戏画布，视觉上也与像素游戏框架不一致。

## 改动内容

- 将不可达反馈改为世界地图画布内的 `<output>` 提示。
- 复用游戏界面的像素字体、边框、背景和阴影语言。
- 提示显示 2.5 秒；重复触发时清除旧计时器并重新计时。
- 组件卸载时移除 Phaser 事件监听并清理计时器。

## 影响范围

本 PR 只调整不可达消息的展示位置与生命周期，不修改地图缩放、区域可用条件、角色状态或导航行为。

## 验证

- Biome format / 全仓 lint
- Oxlint correctness / suspicious
- Next route typegen
- Web TypeScript 检查
- Web 生产构建
- `git diff --check`