### PR TITLE
feat(message): 增加 Web 私聊通道与内部 API

### DIFF
--- a/packages/message/src/internal-api.ts
+++ b/packages/message/src/internal-api.ts
@@ -4,6 +4,7 @@ import type LarkBot from "@satorijs/adapter-lark";
 import type OneBotBot from "@yuiju/satorijs-adapter-onebot";
 import { SUBJECT_NAME } from "@yuiju/utils";
 import { getYuijuConfig } from "@yuiju/utils/config/config";
+import { webChatMessageInputSchema } from "@yuiju/utils/types/web-chat";
 import { Hono } from "hono";
 import { llmManager } from "@/llm/manager";
 import { stickerState } from "@/state/sticker";
@@ -14,6 +15,7 @@ import {
   createStoredSatoriGroupBotMessage,
 } from "@/utils/message/satori";
 import type { StoredSatoriGroupMessage } from "@/utils/message/types";
+import { chatThroughWebChannel, getWebChatSticker } from "@/web-chat";
 
 type MessagePlatform = "onebot" | "lark";
 
@@ -78,6 +80,43 @@ export function startMessageInternalApi(input: InternalApiInput) {
         key: sticker.key,
         description: sticker.description,
       })),
+    });
+  });
+
+  app.post("/internal/web/messages", async (context) => {
+    if (!config.message.web.enabled) {
+      return context.json({ error: { code: "WEB_CHAT_DISABLED" } }, 403);
+    }
+
+    let body: unknown;
+    try {
+      body = await context.req.json();
+    } catch {
+      return context.json({ error: { code: "INVALID_WEB_CHAT_MESSAGE" } }, 400);
+    }
+
+    const parsedMessage = webChatMessageInputSchema.safeParse(body);
+    if (!parsedMessage.success) {
+      return context.json({ error: { code: "INVALID_WEB_CHAT_MESSAGE" } }, 400);
+    }
+
+    const result = await chatThroughWebChannel(parsedMessage.data);
+    return context.json(result);
+  });
+
+  app.get("/internal/web/stickers/:key", (context) => {
+    if (!config.message.web.enabled) {
+      return context.json({ error: { code: "WEB_CHAT_DISABLED" } }, 403);
+    }
+
+    const sticker = getWebChatSticker(context.req.param("key"));
+    if (!sticker) {
+      return context.body(null, 404);
+    }
+
+    return context.body(new Uint8Array(sticker.fileBuffer), 200, {
+      "Cache-Control": "private, max-age=86400",
+      "Content-Type": sticker.contentType,
     });
   });
 

--- a/packages/message/src/web-chat.ts
+++ b/packages/message/src/web-chat.ts
@@ -1,0 +1,141 @@
+import { extname } from "node:path";
+import { h } from "@satorijs/core";
+import { getYuijuConfig } from "@yuiju/utils/config/config";
+import { SUBJECT_NAME } from "@yuiju/utils/constants/character";
+import type {
+  WebChatMessageInput,
+  WebChatReplyPart,
+  WebChatResult,
+} from "@yuiju/utils/types/web-chat";
+import { llmManager } from "@/llm/manager";
+import { stickerState } from "@/state/sticker";
+import { buildSatoriPrivateSessionKey } from "@/utils/message/satori";
+import type { HistoryMessageSegment, StoredSatoriPrivateMessage } from "@/utils/message/types";
+
+function createWebPrivateMessage(input: WebChatMessageInput): StoredSatoriPrivateMessage {
+  const { ownerId, ownerName } = getYuijuConfig().message.web;
+
+  return {
+    source: "satori",
+    scene: "private",
+    platform: "web",
+    messageId: input.messageId,
+    channelId: ownerId,
+    sessionId: buildSatoriPrivateSessionKey("web", ownerId),
+    sessionLabel: ownerName,
+    sender: {
+      id: ownerId,
+      displayName: ownerName,
+      isSelf: false,
+    },
+    timestamp: input.sentAt,
+    elements: [h.text(input.text)],
+    content: [{ type: "text", data: { text: input.text } }],
+  };
+}
+
+function projectWebReplyContent(elements: h[]): HistoryMessageSegment[] {
+  return elements.map((element) => {
+    if (element.type === "text") {
+      return { type: "text", data: { text: String(element.attrs.content ?? "") } };
+    }
+
+    const sticker = stickerState.getByKey(String(element.attrs.summary ?? ""));
+    return {
+      type: "image",
+      data: { description: sticker?.description },
+    };
+  });
+}
+
+function appendWebReplyParts(parts: WebChatReplyPart[], elements: h[], needsLineBreak: boolean) {
+  if (needsLineBreak && elements.length > 0) {
+    parts.push({ type: "text", text: "\n" });
+  }
+
+  for (const element of elements) {
+    if (element.type === "text") {
+      parts.push({ type: "text", text: String(element.attrs.content ?? "") });
+      continue;
+    }
+
+    if (element.type === "image") {
+      const key = String(element.attrs.summary ?? "");
+      parts.push({
+        type: "sticker",
+        key,
+        url: `/api/chat/stickers/${encodeURIComponent(key)}`,
+      });
+    }
+  }
+}
+
+export async function chatThroughWebChannel(input: WebChatMessageInput): Promise<WebChatResult> {
+  const sourceMessage = createWebPrivateMessage(input);
+  await llmManager.recordPrivateMessage(sourceMessage);
+
+  const result = await llmManager.chatWithLLM(sourceMessage);
+  if (result.status === "cancelled") {
+    return { status: "superseded" };
+  }
+  if (result.status === "failed") {
+    return { status: "failed" };
+  }
+  if (!llmManager.isLatestPrivateChatRequest(sourceMessage.sessionId, result.requestId)) {
+    return { status: "superseded" };
+  }
+  if (!result.shouldReply || !result.reply.trim()) {
+    return { status: "no-reply" };
+  }
+
+  const parts: WebChatReplyPart[] = [];
+  const replyLines = result.reply.split("\n").filter((line) => line.trim().length > 0);
+  const createdAt = Date.now();
+
+  for (const [lineIndex, line] of replyLines.entries()) {
+    const elements = stickerState.buildSatoriElementsFromLine(line);
+    if (!elements.length) {
+      continue;
+    }
+
+    appendWebReplyParts(parts, elements, parts.length > 0);
+    await llmManager.recordPrivateMessage({
+      ...sourceMessage,
+      messageId: `${input.messageId}:reply:${lineIndex}`,
+      sender: {
+        id: "web:yuiju",
+        displayName: SUBJECT_NAME,
+        isSelf: true,
+      },
+      elements,
+      timestamp: createdAt,
+      content: projectWebReplyContent(elements),
+    });
+  }
+
+  return {
+    status: "replied",
+    reply: {
+      id: `${input.messageId}:reply`,
+      parts,
+      createdAt,
+    },
+  };
+}
+
+export function getWebChatSticker(key: string) {
+  const sticker = stickerState.getByKey(key);
+  if (!sticker) {
+    return null;
+  }
+
+  const extension = extname(sticker.absoluteUri).toLowerCase();
+  if (extension !== ".png" && extension !== ".webp") {
+    throw new Error(`unsupported Web sticker format: ${extension}`);
+  }
+
+  return {
+    fileBuffer: sticker.fileBuffer,
+    contentType: extension === ".png" ? "image/png" : "image/webp",
+  };
+}

--- a/packages/utils/src/config/config-schema.ts
+++ b/packages/utils/src/config/config-schema.ts
@@ -18,6 +18,15 @@ export interface YuijuMessageInternalApiConfig {
 }
 
 /**
+ * Web 私聊渠道配置。
+ */
+export interface YuijuMessageWebConfig {
+  enabled: boolean;
+  ownerId: string;
+  ownerName: string;
+}
+
+/**
  * OneBot 消息平台配置。
  */
 export interface YuijuOneBotConfig extends YuijuMessageWebSocketReconnectConfig {
@@ -72,6 +81,7 @@ export interface YuijuMessageConfig {
   onebot: YuijuOneBotConfig;
   lark: YuijuLarkConfig;
   internalApi: YuijuMessageInternalApiConfig;
+  web: YuijuMessageWebConfig;
   proactive: {
     onebotGroupTargetId?: number;
     larkGroupTargetId?: string;
@@ -186,6 +196,12 @@ const yuijuMessageInternalApiConfigSchema: z.ZodType<YuijuMessageInternalApiConf
   port: z.number(),
 });
 
+const yuijuMessageWebConfigSchema: z.ZodType<YuijuMessageWebConfig> = z.strictObject({
+  enabled: z.boolean(),
+  ownerId: z.string().trim().min(1),
+  ownerName: z.string().trim().min(1),
+});
+
 const yuijuOneBotConfigSchema: z.ZodType<YuijuOneBotConfig> = z.object({
   ...yuijuMessageWebSocketReconnectConfigShape,
   protocol: z.literal("ws"),
@@ -218,6 +234,7 @@ const yuijuMessageConfigSchema: z.ZodType<YuijuMessageConfig> = z.object({
   onebot: yuijuOneBotConfigSchema,
   lark: yuijuLarkConfigSchema,
   internalApi: yuijuMessageInternalApiConfigSchema,
+  web: yuijuMessageWebConfigSchema,
   proactive: z.object({
     onebotGroupTargetId: z.number().optional(),
     larkGroupTargetId: z.string().optional(),

--- a/packages/utils/src/types/web-chat.ts
+++ b/packages/utils/src/types/web-chat.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+export const webChatMessageInputSchema = z.strictObject({
+  messageId: z.string().trim().min(1).max(120),
+  text: z.string().trim().min(1).max(2000),
+  sentAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+});
+
+export type WebChatMessageInput = z.infer<typeof webChatMessageInputSchema>;
+
+export const webChatReplyPartSchema = z.discriminatedUnion("type", [
+  z.strictObject({
+    type: z.literal("text"),
+    text: z.string(),
+  }),
+  z.strictObject({
+    type: z.literal("sticker"),
+    key: z.string().regex(/^[a-zA-Z0-9_-]+$/),
+    url: z.string().startsWith("/api/chat/stickers/"),
+  }),
+]);
+
+export type WebChatReplyPart = z.infer<typeof webChatReplyPartSchema>;
+
+export const webChatResultSchema = z.discriminatedUnion("status", [
+  z.strictObject({
+    status: z.literal("replied"),
+    reply: z.strictObject({
+      id: z.string().min(1),
+      parts: z.array(webChatReplyPartSchema).min(1),
+      createdAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+    }),
+  }),
+  z.strictObject({ status: z.literal("no-reply") }),
+  z.strictObject({ status: z.literal("failed") }),
+  z.strictObject({ status: z.literal("superseded") }),
+]);
+
+export type WebChatResult = z.infer<typeof webChatResultSchema>;

--- a/packages/web/app/api/chat/messages/route.ts
+++ b/packages/web/app/api/chat/messages/route.ts
@@ -1,0 +1,56 @@
+import { getYuijuConfig } from "@yuiju/utils/config/config";
+import { webChatMessageInputSchema } from "@yuiju/utils/types/web-chat";
+import { sendWebChatMessage } from "@/lib/message-internal-api";
+import { isPublicDeployment } from "@/lib/public-deployment";
+
+export const runtime = "nodejs";
+export const maxDuration = 120;
+
+type ChatErrorCode = "INVALID_MESSAGE" | "CHAT_DISABLED" | "CHAT_FAILED" | "MESSAGE_SUPERSEDED";
+
+function errorResponse(status: number, code: ChatErrorCode, message: string) {
+  return Response.json({ error: { code, message } }, { status });
+}
+
+export async function POST(request: Request) {
+  if (isPublicDeployment() || !getYuijuConfig().message.web.enabled) {
+    return errorResponse(403, "CHAT_DISABLED", "Web 私聊渠道未启用");
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse(400, "INVALID_MESSAGE", "请求体必须是有效 JSON");
+  }
+
+  const input = webChatMessageInputSchema.safeParse(body);
+  if (!input.success) {
+    return errorResponse(400, "INVALID_MESSAGE", "消息格式不正确");
+  }
+
+  let result: Awaited<ReturnType<typeof sendWebChatMessage>>;
+  try {
+    result = await sendWebChatMessage(input.data);
+  } catch (error) {
+    console.error("Web chat internal API request failed", error);
+    return errorResponse(502, "CHAT_FAILED", "悠酱暂时无法组织回复");
+  }
+
+  if (result.status === "failed") {
+    return errorResponse(500, "CHAT_FAILED", "悠酱暂时无法组织回复");
+  }
+  if (result.status === "superseded") {
+    return errorResponse(409, "MESSAGE_SUPERSEDED", "这条消息已被更新的消息替代");
+  }
+  if (result.status === "no-reply") {
+    return Response.json({ data: { status: "NO_REPLY" } });
+  }
+
+  return Response.json({
+    data: {
+      status: "REPLIED",
+      reply: result.reply,
+    },
+  });
+}

--- a/packages/web/app/api/chat/stickers/[key]/route.ts
+++ b/packages/web/app/api/chat/stickers/[key]/route.ts
@@ -1,0 +1,38 @@
+import { getYuijuConfig } from "@yuiju/utils/config/config";
+import { fetchWebChatSticker } from "@/lib/message-internal-api";
+import { isPublicDeployment } from "@/lib/public-deployment";
+
+export const runtime = "nodejs";
+
+export async function GET(_request: Request, context: { params: Promise<{ key: string }> }) {
+  if (isPublicDeployment() || !getYuijuConfig().message.web.enabled) {
+    return new Response(null, { status: 404 });
+  }
+
+  const { key } = await context.params;
+
+  try {
+    const internalResponse = await fetchWebChatSticker(key);
+    if (internalResponse.status === 404) {
+      return new Response(null, { status: 404 });
+    }
+    if (!internalResponse.ok) {
+      return new Response(null, { status: 502 });
+    }
+
+    const contentType = internalResponse.headers.get("content-type");
+    if (!contentType) {
+      return new Response(null, { status: 502 });
+    }
+
+    return new Response(internalResponse.body, {
+      headers: {
+        "Cache-Control": "private, max-age=86400",
+        "Content-Type": contentType,
+      },
+    });
+  } catch (error) {
+    console.error("Web chat sticker internal API request failed", error);
+    return new Response(null, { status: 502 });
+  }
+}

--- a/packages/web/lib/message-internal-api.ts
+++ b/packages/web/lib/message-internal-api.ts
@@ -1,0 +1,34 @@
+import "server-only";
+
+import { getYuijuConfig } from "@yuiju/utils/config/config";
+import {
+  type WebChatMessageInput,
+  type WebChatResult,
+  webChatResultSchema,
+} from "@yuiju/utils/types/web-chat";
+
+function getMessageInternalApiUrl(pathname: string): URL {
+  const { host, port } = getYuijuConfig().message.internalApi;
+  return new URL(pathname, `http://${host}:${port}`);
+}
+
+export async function sendWebChatMessage(input: WebChatMessageInput): Promise<WebChatResult> {
+  const response = await fetch(getMessageInternalApiUrl("/internal/web/messages"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`message internal API returned ${response.status}`);
+  }
+
+  return webChatResultSchema.parse(await response.json());
+}
+
+export function fetchWebChatSticker(key: string): Promise<Response> {
+  return fetch(getMessageInternalApiUrl(`/internal/web/stickers/${encodeURIComponent(key)}`), {
+    cache: "no-store",
+  });
+}

--- a/yuiju.config.json.example
+++ b/yuiju.config.json.example
@@ -39,6 +39,11 @@
     }
   },
   "message": {
+    "web": {
+      "enabled": false,
+      "ownerId": "web-user",
+      "ownerName": "主人"
+    },
     "proactive": {
       "onebotGroupTargetId": 838986741,
       "larkGroupTargetId": "xxx"


### PR DESCRIPTION
## 背景

当前 Web 聊天能力只存在于 fork，最新上游尚无可复用的 Web 私聊入口。直接由 Next.js 引用 message 包还会在 Web 进程中创建另一份消息运行时状态，无法与正在运行的 message 服务共享会话和表情注册表。

Related to #109
Related to #112

## 本次改动

- 在 message 服务的内部 API 增加 Web 私聊消息与表情读取接口
- 将 Web 输入转换为现有 Satori 私聊消息，复用最新请求判定、LLM 回复和 Redis 会话备份
- 在 utils 中集中维护 Web 聊天请求/响应 schema，供 message 与 web 两端共同校验
- 在 Next.js 侧增加仅服务端使用的内部 API 适配器和对外 Route Handler
- 公开展示模式或配置未启用时拒绝 Web 私聊
- 表情仅通过二进制代理返回，不暴露本地文件路径

## 配置

在 `message.web` 中显式配置：

- `enabled`：是否启用 Web 私聊
- `ownerId`：Web 用户稳定标识
- `ownerName`：进入对话历史的显示名称

示例配置默认关闭该能力。

## 明确不包含

- 聊天页面 UI（后续独立 PR 迁移现有页面）
- MongoDB 历史记录与刷新恢复
- 回复耗时优化
- 设置页面和 E2E/单测文件

## 验证

- Biome lint
- Oxlint
- utils、message、web TypeScript 检查
- Next.js production build
- `git diff --check`