### PR TITLE
feat(web): 迁移本地设置页与界面偏好

### DIFF
--- a/packages/message/src/internal-api.ts
+++ b/packages/message/src/internal-api.ts
@@ -4,6 +4,7 @@ import type LarkBot from "@satorijs/adapter-lark";
 import type OneBotBot from "@yuiju/satorijs-adapter-onebot";
 import { SUBJECT_NAME } from "@yuiju/utils";
 import { getYuijuConfig } from "@yuiju/utils/config/config";
+import { webChatMessageInputSchema } from "@yuiju/utils/types/web-chat";
 import { Hono } from "hono";
 import { llmManager } from "@/llm/manager";
 import { stickerState } from "@/state/sticker";
@@ -14,6 +15,7 @@ import {
   createStoredSatoriGroupBotMessage,
 } from "@/utils/message/satori";
 import type { StoredSatoriGroupMessage } from "@/utils/message/types";
+import { chatThroughWebChannel, getWebChatSticker } from "@/web-chat";
 
 type MessagePlatform = "onebot" | "lark";
 
@@ -78,6 +80,43 @@ export function startMessageInternalApi(input: InternalApiInput) {
         key: sticker.key,
         description: sticker.description,
       })),
+    });
+  });
+
+  app.post("/internal/web/messages", async (context) => {
+    if (!config.message.web.enabled) {
+      return context.json({ error: { code: "WEB_CHAT_DISABLED" } }, 403);
+    }
+
+    let body: unknown;
+    try {
+      body = await context.req.json();
+    } catch {
+      return context.json({ error: { code: "INVALID_WEB_CHAT_MESSAGE" } }, 400);
+    }
+
+    const parsedMessage = webChatMessageInputSchema.safeParse(body);
+    if (!parsedMessage.success) {
+      return context.json({ error: { code: "INVALID_WEB_CHAT_MESSAGE" } }, 400);
+    }
+
+    const result = await chatThroughWebChannel(parsedMessage.data);
+    return context.json(result);
+  });
+
+  app.get("/internal/web/stickers/:key", (context) => {
+    if (!config.message.web.enabled) {
+      return context.json({ error: { code: "WEB_CHAT_DISABLED" } }, 403);
+    }
+
+    const sticker = getWebChatSticker(context.req.param("key"));
+    if (!sticker) {
+      return context.body(null, 404);
+    }
+
+    return context.body(new Uint8Array(sticker.fileBuffer), 200, {
+      "Cache-Control": "private, max-age=86400",
+      "Content-Type": sticker.contentType,
     });
   });
 

--- a/packages/message/src/web-chat.ts
+++ b/packages/message/src/web-chat.ts
@@ -1,0 +1,141 @@
+import { extname } from "node:path";
+import { h } from "@satorijs/core";
+import { getYuijuConfig } from "@yuiju/utils/config/config";
+import { SUBJECT_NAME } from "@yuiju/utils/constants/character";
+import type {
+  WebChatMessageInput,
+  WebChatReplyPart,
+  WebChatResult,
+} from "@yuiju/utils/types/web-chat";
+import { llmManager } from "@/llm/manager";
+import { stickerState } from "@/state/sticker";
+import { buildSatoriPrivateSessionKey } from "@/utils/message/satori";
+import type { HistoryMessageSegment, StoredSatoriPrivateMessage } from "@/utils/message/types";
+
+function createWebPrivateMessage(input: WebChatMessageInput): StoredSatoriPrivateMessage {
+  const { ownerId, ownerName } = getYuijuConfig().message.web;
+
+  return {
+    source: "satori",
+    scene: "private",
+    platform: "web",
+    messageId: input.messageId,
+    channelId: ownerId,
+    sessionId: buildSatoriPrivateSessionKey("web", ownerId),
+    sessionLabel: ownerName,
+    sender: {
+      id: ownerId,
+      displayName: ownerName,
+      isSelf: false,
+    },
+    timestamp: input.sentAt,
+    elements: [h.text(input.text)],
+    content: [{ type: "text", data: { text: input.text } }],
+  };
+}
+
+function projectWebReplyContent(elements: h[]): HistoryMessageSegment[] {
+  return elements.map((element) => {
+    if (element.type === "text") {
+      return { type: "text", data: { text: String(element.attrs.content ?? "") } };
+    }
+
+    const sticker = stickerState.getByKey(String(element.attrs.summary ?? ""));
+    return {
+      type: "image",
+      data: { description: sticker?.description },
+    };
+  });
+}
+
+function appendWebReplyParts(parts: WebChatReplyPart[], elements: h[], needsLineBreak: boolean) {
+  if (needsLineBreak && elements.length > 0) {
+    parts.push({ type: "text", text: "\n" });
+  }
+
+  for (const element of elements) {
+    if (element.type === "text") {
+      parts.push({ type: "text", text: String(element.attrs.content ?? "") });
+      continue;
+    }
+
+    if (element.type === "image") {
+      const key = String(element.attrs.summary ?? "");
+      parts.push({
+        type: "sticker",
+        key,
+        url: `/api/chat/stickers/${encodeURIComponent(key)}`,
+      });
+    }
+  }
+}
+
+export async function chatThroughWebChannel(input: WebChatMessageInput): Promise<WebChatResult> {
+  const sourceMessage = createWebPrivateMessage(input);
+  await llmManager.recordPrivateMessage(sourceMessage);
+
+  const result = await llmManager.chatWithLLM(sourceMessage);
+  if (result.status === "cancelled") {
+    return { status: "superseded" };
+  }
+  if (result.status === "failed") {
+    return { status: "failed" };
+  }
+  if (!llmManager.isLatestPrivateChatRequest(sourceMessage.sessionId, result.requestId)) {
+    return { status: "superseded" };
+  }
+  if (!result.shouldReply || !result.reply.trim()) {
+    return { status: "no-reply" };
+  }
+
+  const parts: WebChatReplyPart[] = [];
+  const replyLines = result.reply.split("\n").filter((line) => line.trim().length > 0);
+  const createdAt = Date.now();
+
+  for (const [lineIndex, line] of replyLines.entries()) {
+    const elements = stickerState.buildSatoriElementsFromLine(line);
+    if (!elements.length) {
+      continue;
+    }
+
+    appendWebReplyParts(parts, elements, parts.length > 0);
+    await llmManager.recordPrivateMessage({
+      ...sourceMessage,
+      messageId: `${input.messageId}:reply:${lineIndex}`,
+      sender: {
+        id: "web:yuiju",
+        displayName: SUBJECT_NAME,
+        isSelf: true,
+      },
+      elements,
+      timestamp: createdAt,
+      content: projectWebReplyContent(elements),
+    });
+  }
+
+  return {
+    status: "replied",
+    reply: {
+      id: `${input.messageId}:reply`,
+      parts,
+      createdAt,
+    },
+  };
+}
+
+export function getWebChatSticker(key: string) {
+  const sticker = stickerState.getByKey(key);
+  if (!sticker) {
+    return null;
+  }
+
+  const extension = extname(sticker.absoluteUri).toLowerCase();
+  if (extension !== ".png" && extension !== ".webp") {
+    throw new Error(`unsupported Web sticker format: ${extension}`);
+  }
+
+  return {
+    fileBuffer: sticker.fileBuffer,
+    contentType: extension === ".png" ? "image/png" : "image/webp",
+  };
+}

--- a/packages/utils/src/config/config-schema.ts
+++ b/packages/utils/src/config/config-schema.ts
@@ -18,6 +18,15 @@ export interface YuijuMessageInternalApiConfig {
 }
 
 /**
+ * Web 私聊渠道配置。
+ */
+export interface YuijuMessageWebConfig {
+  enabled: boolean;
+  ownerId: string;
+  ownerName: string;
+}
+
+/**
  * OneBot 消息平台配置。
  */
 export interface YuijuOneBotConfig extends YuijuMessageWebSocketReconnectConfig {
@@ -72,6 +81,7 @@ export interface YuijuMessageConfig {
   onebot: YuijuOneBotConfig;
   lark: YuijuLarkConfig;
   internalApi: YuijuMessageInternalApiConfig;
+  web: YuijuMessageWebConfig;
   proactive: {
     onebotGroupTargetId?: number;
     larkGroupTargetId?: string;
@@ -186,6 +196,12 @@ const yuijuMessageInternalApiConfigSchema: z.ZodType<YuijuMessageInternalApiConf
   port: z.number(),
 });
 
+const yuijuMessageWebConfigSchema: z.ZodType<YuijuMessageWebConfig> = z.strictObject({
+  enabled: z.boolean(),
+  ownerId: z.string().trim().min(1),
+  ownerName: z.string().trim().min(1),
+});
+
 const yuijuOneBotConfigSchema: z.ZodType<YuijuOneBotConfig> = z.object({
   ...yuijuMessageWebSocketReconnectConfigShape,
   protocol: z.literal("ws"),
@@ -218,6 +234,7 @@ const yuijuMessageConfigSchema: z.ZodType<YuijuMessageConfig> = z.object({
   onebot: yuijuOneBotConfigSchema,
   lark: yuijuLarkConfigSchema,
   internalApi: yuijuMessageInternalApiConfigSchema,
+  web: yuijuMessageWebConfigSchema,
   proactive: z.object({
     onebotGroupTargetId: z.number().optional(),
     larkGroupTargetId: z.string().optional(),

--- a/packages/utils/src/types/web-chat.ts
+++ b/packages/utils/src/types/web-chat.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+export const webChatMessageInputSchema = z.strictObject({
+  messageId: z.string().trim().min(1).max(120),
+  text: z.string().trim().min(1).max(2000),
+  sentAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+});
+
+export type WebChatMessageInput = z.infer<typeof webChatMessageInputSchema>;
+
+export const webChatReplyPartSchema = z.discriminatedUnion("type", [
+  z.strictObject({
+    type: z.literal("text"),
+    text: z.string(),
+  }),
+  z.strictObject({
+    type: z.literal("sticker"),
+    key: z.string().regex(/^[a-zA-Z0-9_-]+$/),
+    url: z.string().startsWith("/api/chat/stickers/"),
+  }),
+]);
+
+export type WebChatReplyPart = z.infer<typeof webChatReplyPartSchema>;
+
+export const webChatResultSchema = z.discriminatedUnion("status", [
+  z.strictObject({
+    status: z.literal("replied"),
+    reply: z.strictObject({
+      id: z.string().min(1),
+      parts: z.array(webChatReplyPartSchema).min(1),
+      createdAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+    }),
+  }),
+  z.strictObject({ status: z.literal("no-reply") }),
+  z.strictObject({ status: z.literal("failed") }),
+  z.strictObject({ status: z.literal("superseded") }),
+]);
+
+export type WebChatResult = z.infer<typeof webChatResultSchema>;

--- a/packages/web/app/api/chat/messages/route.ts
+++ b/packages/web/app/api/chat/messages/route.ts
@@ -1,0 +1,56 @@
+import { getYuijuConfig } from "@yuiju/utils/config/config";
+import { webChatMessageInputSchema } from "@yuiju/utils/types/web-chat";
+import { sendWebChatMessage } from "@/lib/message-internal-api";
+import { isPublicDeployment } from "@/lib/public-deployment";
+
+export const runtime = "nodejs";
+export const maxDuration = 120;
+
+type ChatErrorCode = "INVALID_MESSAGE" | "CHAT_DISABLED" | "CHAT_FAILED" | "MESSAGE_SUPERSEDED";
+
+function errorResponse(status: number, code: ChatErrorCode, message: string) {
+  return Response.json({ error: { code, message } }, { status });
+}
+
+export async function POST(request: Request) {
+  if (isPublicDeployment() || !getYuijuConfig().message.web.enabled) {
+    return errorResponse(403, "CHAT_DISABLED", "Web 私聊渠道未启用");
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse(400, "INVALID_MESSAGE", "请求体必须是有效 JSON");
+  }
+
+  const input = webChatMessageInputSchema.safeParse(body);
+  if (!input.success) {
+    return errorResponse(400, "INVALID_MESSAGE", "消息格式不正确");
+  }
+
+  let result: Awaited<ReturnType<typeof sendWebChatMessage>>;
+  try {
+    result = await sendWebChatMessage(input.data);
+  } catch (error) {
+    console.error("Web chat internal API request failed", error);
+    return errorResponse(502, "CHAT_FAILED", "悠酱暂时无法组织回复");
+  }
+
+  if (result.status === "failed") {
+    return errorResponse(500, "CHAT_FAILED", "悠酱暂时无法组织回复");
+  }
+  if (result.status === "superseded") {
+    return errorResponse(409, "MESSAGE_SUPERSEDED", "这条消息已被更新的消息替代");
+  }
+  if (result.status === "no-reply") {
+    return Response.json({ data: { status: "NO_REPLY" } });
+  }
+
+  return Response.json({
+    data: {
+      status: "REPLIED",
+      reply: result.reply,
+    },
+  });
+}

--- a/packages/web/app/api/chat/stickers/[key]/route.ts
+++ b/packages/web/app/api/chat/stickers/[key]/route.ts
@@ -1,0 +1,38 @@
+import { getYuijuConfig } from "@yuiju/utils/config/config";
+import { fetchWebChatSticker } from "@/lib/message-internal-api";
+import { isPublicDeployment } from "@/lib/public-deployment";
+
+export const runtime = "nodejs";
+
+export async function GET(_request: Request, context: { params: Promise<{ key: string }> }) {
+  if (isPublicDeployment() || !getYuijuConfig().message.web.enabled) {
+    return new Response(null, { status: 404 });
+  }
+
+  const { key } = await context.params;
+
+  try {
+    const internalResponse = await fetchWebChatSticker(key);
+    if (internalResponse.status === 404) {
+      return new Response(null, { status: 404 });
+    }
+    if (!internalResponse.ok) {
+      return new Response(null, { status: 502 });
+    }
+
+    const contentType = internalResponse.headers.get("content-type");
+    if (!contentType) {
+      return new Response(null, { status: 502 });
+    }
+
+    return new Response(internalResponse.body, {
+      headers: {
+        "Cache-Control": "private, max-age=86400",
+        "Content-Type": contentType,
+      },
+    });
+  } catch (error) {
+    console.error("Web chat sticker internal API request failed", error);
+    return new Response(null, { status: 502 });
+  }
+}

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -156,3 +156,20 @@
     @apply bg-background text-foreground;
   }
 }
+
+html[data-show-message-time="false"] .chat-message-time {
+  display: none;
+}
+
+html[data-reduce-motion="true"] {
+  scroll-behavior: auto !important;
+}
+
+html[data-reduce-motion="true"] *,
+html[data-reduce-motion="true"] *::before,
+html[data-reduce-motion="true"] *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  scroll-behavior: auto !important;
+  transition-duration: 0.01ms !important;
+}

--- a/packages/web/app/settings/page.tsx
+++ b/packages/web/app/settings/page.tsx
@@ -1,0 +1,14 @@
+import { notFound } from "next/navigation";
+import { isPublicDeployment } from "@/lib/public-deployment";
+import { SettingsClient } from "./settings-client";
+import { getSettingsSnapshot } from "./settings-data";
+
+export const dynamic = "force-dynamic";
+
+export default async function SettingsPage() {
+  if (isPublicDeployment()) {
+    notFound();
+  }
+
+  return <SettingsClient snapshot={await getSettingsSnapshot()} />;
+}

--- a/packages/web/app/settings/settings-client.tsx
+++ b/packages/web/app/settings/settings-client.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import {
+  Activity,
+  BrainCircuit,
+  Check,
+  Clock3,
+  Database,
+  Eye,
+  Gauge,
+  MessageCircle,
+  RefreshCw,
+  Server,
+  SlidersHorizontal,
+  UserRound,
+  Wifi,
+  X,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import { useInterfacePreferences } from "@/lib/components/interface-preferences";
+import type { ServiceStatus, SettingsSnapshot } from "./settings-data";
+
+function formatDate(value: string | null): string {
+  if (!value) {
+    return "暂无归档";
+  }
+
+  return new Intl.DateTimeFormat("zh-CN", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function StatusMark({ status }: { status: ServiceStatus }) {
+  const online = status === "online";
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 text-xs font-semibold ${online ? "text-[#397c63]" : "text-[#ad5e69]"}`}
+    >
+      <span className={`h-2 w-2 rounded-full ${online ? "bg-[#63b28d]" : "bg-[#d9848f]"}`} />
+      {online ? "正常" : "不可用"}
+    </span>
+  );
+}
+
+function StatusBand({ snapshot }: { snapshot: SettingsSnapshot }) {
+  const items = [
+    {
+      label: "运行环境",
+      value: snapshot.environment === "development" ? "开发环境" : "生产环境",
+      icon: Server,
+      tone: "text-[#6c78b8]",
+    },
+    {
+      label: "聊天模型",
+      value: snapshot.chat.model,
+      icon: MessageCircle,
+      tone: "text-[#5a91b9]",
+    },
+    {
+      label: "MongoDB",
+      value: <StatusMark status={snapshot.mongo.status} />,
+      icon: Database,
+      tone: "text-[#a37582]",
+    },
+    {
+      label: "Redis",
+      value: <StatusMark status={snapshot.redis.status} />,
+      icon: Wifi,
+      tone: "text-[#4e9b86]",
+    },
+  ];
+
+  return (
+    <div className="grid overflow-hidden rounded-lg border border-[#d9e6f5] bg-white sm:grid-cols-2 lg:grid-cols-4">
+      {items.map((item, index) => {
+        const Icon = item.icon;
+        return (
+          <div
+            key={item.label}
+            className={`flex min-h-22 items-center gap-3 px-5 py-4 ${index === 1 ? "border-t border-[#d9e6f5] sm:border-l sm:border-t-0" : ""} ${index === 2 ? "border-t border-[#d9e6f5] lg:border-l lg:border-t-0" : ""} ${index === 3 ? "border-t border-[#d9e6f5] sm:border-l lg:border-t-0" : ""}`}
+          >
+            <Icon className={`h-4 w-4 shrink-0 ${item.tone}`} aria-hidden="true" />
+            <div className="min-w-0">
+              <p className="text-[11px] font-medium tracking-wide text-[#8b96a4]">{item.label}</p>
+              <p className="mt-1 truncate text-sm font-semibold text-[#2b2f36]">{item.value}</p>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function SettingsRow({
+  icon: Icon,
+  label,
+  detail,
+  value,
+}: {
+  icon: typeof Activity;
+  label: string;
+  detail?: string;
+  value: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-18 items-center gap-3 border-b border-[#e6eef7] py-4 last:border-b-0">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[#f4f8fc] text-[#7e8ccb]">
+        <Icon className="h-4 w-4" aria-hidden="true" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-[#30363e]">{label}</p>
+        {detail ? <p className="mt-1 text-xs leading-5 text-[#8a95a2]">{detail}</p> : null}
+      </div>
+      <div className="shrink-0 text-right text-sm text-[#5d6875]">{value}</div>
+    </div>
+  );
+}
+
+function PreferenceSwitch({
+  checked,
+  label,
+  onChange,
+}: {
+  checked: boolean;
+  label: string;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      title={label}
+      onClick={() => onChange(!checked)}
+      className={`relative h-7 w-12 rounded-full p-1 transition-colors ${checked ? "bg-[#7e8ccb]" : "bg-[#cbd7e4]"}`}
+    >
+      <span
+        className={`block h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${checked ? "translate-x-5" : "translate-x-0"}`}
+      />
+    </button>
+  );
+}
+
+export function SettingsClient({ snapshot }: { snapshot: SettingsSnapshot }) {
+  const router = useRouter();
+  const [isRefreshing, startRefreshing] = useTransition();
+  const { showMessageTime, reduceMotion, setShowMessageTime, setReduceMotion } =
+    useInterfacePreferences();
+
+  return (
+    <main className="min-h-[calc(100vh-78px)] bg-[#f7fbff] px-4 py-8 text-[#2b2f36] sm:px-6">
+      <div className="mx-auto max-w-240">
+        <header className="flex flex-col items-start justify-between gap-4 border-b border-[#d9e6f5] pb-6 sm:flex-row sm:items-end">
+          <div>
+            <div className="flex items-center gap-2 text-xs font-semibold tracking-[0.12em] text-[#7e8ccb]">
+              <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
+              LOCAL CONSOLE
+            </div>
+            <h1 className="mt-2 text-3xl font-black tracking-tight">设置</h1>
+            <p className="mt-2 text-sm text-[#74808e]">运行状态、记忆归档与当前浏览器偏好</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => startRefreshing(() => router.refresh())}
+            disabled={isRefreshing}
+            className="inline-flex h-9 items-center gap-2 rounded-lg border border-[#d9e6f5] bg-white px-3 text-xs font-semibold text-[#657285] transition-colors hover:border-[#91c4ee] hover:text-[#2b2f36] disabled:cursor-wait disabled:opacity-60"
+            title="刷新运行状态"
+          >
+            <RefreshCw
+              className={`h-3.5 w-3.5 ${isRefreshing ? "animate-spin" : ""}`}
+              aria-hidden="true"
+            />
+            刷新状态
+          </button>
+        </header>
+
+        <section className="mt-6" aria-labelledby="runtime-status-title">
+          <div className="mb-3 flex items-center justify-between">
+            <h2
+              id="runtime-status-title"
+              className="text-xs font-bold tracking-[0.12em] text-[#7e8ccb]"
+            >
+              运行状态
+            </h2>
+            <span className="text-xs text-[#9aa4af]">
+              更新于 {formatDate(snapshot.generatedAt)}
+            </span>
+          </div>
+          <StatusBand snapshot={snapshot} />
+        </section>
+
+        <div className="mt-8 grid gap-8 lg:grid-cols-2">
+          <section aria-labelledby="web-chat-settings-title">
+            <div className="mb-2 flex items-center gap-2">
+              <MessageCircle className="h-4 w-4 text-[#7e8ccb]" aria-hidden="true" />
+              <h2 id="web-chat-settings-title" className="text-base font-bold">
+                Web 对话
+              </h2>
+            </div>
+            <div className="border-t border-[#d9e6f5]">
+              <SettingsRow
+                icon={Activity}
+                label="Web 私聊"
+                detail="当前网页对话入口"
+                value={
+                  snapshot.chat.enabled ? (
+                    <StatusMark status="online" />
+                  ) : (
+                    <StatusMark status="offline" />
+                  )
+                }
+              />
+              <SettingsRow
+                icon={UserRound}
+                label="对话身份"
+                detail="网页消息使用的角色身份"
+                value={snapshot.chat.identity}
+              />
+            </div>
+          </section>
+
+          <section aria-labelledby="memory-settings-title">
+            <div className="mb-2 flex items-center gap-2">
+              <BrainCircuit className="h-4 w-4 text-[#7e8ccb]" aria-hidden="true" />
+              <h2 id="memory-settings-title" className="text-base font-bold">
+                记忆
+              </h2>
+            </div>
+            <div className="border-t border-[#d9e6f5]">
+              <SettingsRow
+                icon={Database}
+                label="对话归档"
+                detail="MongoDB 中的 conversation Episode"
+                value={snapshot.mongo.episodeCount ?? "不可用"}
+              />
+              <SettingsRow
+                icon={Clock3}
+                label="最近归档"
+                detail="最近一次对话窗口归档时间"
+                value={formatDate(snapshot.mongo.latestArchiveAt)}
+              />
+              <SettingsRow
+                icon={UserRound}
+                label="人物记忆"
+                detail="people 目录中的长期记忆"
+                value={snapshot.personMemory.count ?? "不可用"}
+              />
+              <SettingsRow
+                icon={Gauge}
+                label="互动热度"
+                detail={`${snapshot.chat.identity} 的累计互动热度`}
+                value={snapshot.personMemory.interactionHeat ?? "不可用"}
+              />
+            </div>
+          </section>
+
+          <section className="lg:col-span-2" aria-labelledby="interface-settings-title">
+            <div className="mb-2 flex items-center gap-2">
+              <Eye className="h-4 w-4 text-[#7e8ccb]" aria-hidden="true" />
+              <h2 id="interface-settings-title" className="text-base font-bold">
+                界面偏好
+              </h2>
+            </div>
+            <div className="border-t border-[#d9e6f5]">
+              <SettingsRow
+                icon={Clock3}
+                label="消息时间"
+                detail="在聊天消息下方显示发送时间"
+                value={
+                  <PreferenceSwitch
+                    checked={showMessageTime}
+                    label="显示聊天消息时间"
+                    onChange={setShowMessageTime}
+                  />
+                }
+              />
+              <SettingsRow
+                icon={SlidersHorizontal}
+                label="减少动效"
+                detail="降低页面过渡与循环动画"
+                value={
+                  <PreferenceSwitch
+                    checked={reduceMotion}
+                    label="减少页面动效"
+                    onChange={setReduceMotion}
+                  />
+                }
+              />
+            </div>
+          </section>
+        </div>
+
+        <footer className="mt-8 flex items-center gap-2 border-t border-[#d9e6f5] pt-4 text-xs text-[#97a1ad]">
+          {snapshot.mongo.status === "online" && snapshot.redis.status === "online" ? (
+            <Check className="h-3.5 w-3.5 text-[#63b28d]" aria-hidden="true" />
+          ) : (
+            <X className="h-3.5 w-3.5 text-[#d9848f]" aria-hidden="true" />
+          )}
+          <span>配置与凭据保持只读，状态来自当前运行实例</span>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/packages/web/app/settings/settings-data.ts
+++ b/packages/web/app/settings/settings-data.ts
@@ -1,0 +1,116 @@
+import "server-only";
+
+import { getYuijuConfig } from "@yuiju/utils/config/config";
+import {
+  countRecentMemoryEpisodes,
+  getRecentMemoryEpisodes,
+} from "@yuiju/utils/db/operations/memory-episode";
+import { isDev } from "@yuiju/utils/env";
+import { listPersonMemories } from "@yuiju/utils/memory/person-memory/directory";
+import { readPersonMemoryHeatDocument } from "@yuiju/utils/memory/person-memory/heat";
+import { getRedis } from "@yuiju/utils/redis/client";
+
+export type ServiceStatus = "online" | "offline";
+
+export interface SettingsSnapshot {
+  generatedAt: string;
+  environment: "development" | "production";
+  chat: {
+    enabled: boolean;
+    identity: string;
+    model: string;
+  };
+  mongo: {
+    status: ServiceStatus;
+    episodeCount: number | null;
+    latestArchiveAt: string | null;
+  };
+  redis: {
+    status: ServiceStatus;
+  };
+  personMemory: {
+    status: ServiceStatus;
+    count: number | null;
+    interactionHeat: number | null;
+  };
+}
+
+export async function getSettingsSnapshot(): Promise<SettingsSnapshot> {
+  const config = getYuijuConfig();
+  const ownerName = config.message.web.ownerName;
+
+  const mongoPromise = (async () => {
+    try {
+      const [episodeCount, latestEpisodes] = await Promise.all([
+        countRecentMemoryEpisodes({ sources: ["chat"], types: ["conversation"] }),
+        getRecentMemoryEpisodes({
+          sources: ["chat"],
+          types: ["conversation"],
+          limit: 1,
+          sortField: "createdAt",
+        }),
+      ]);
+      const latestArchive = latestEpisodes[0];
+
+      return {
+        status: "online" as const,
+        episodeCount,
+        latestArchiveAt: latestArchive?.createdAt.toISOString() ?? null,
+      };
+    } catch {
+      return {
+        status: "offline" as const,
+        episodeCount: null,
+        latestArchiveAt: null,
+      };
+    }
+  })();
+
+  const redisPromise = (async () => {
+    try {
+      await getRedis().ping();
+      return { status: "online" as const };
+    } catch {
+      return { status: "offline" as const };
+    }
+  })();
+
+  const personMemoryPromise = (async () => {
+    try {
+      const [directory, heatDocument] = await Promise.all([
+        listPersonMemories(1),
+        readPersonMemoryHeatDocument(),
+      ]);
+      return {
+        status: "online" as const,
+        count: directory.total,
+        interactionHeat: heatDocument[ownerName]?.heat ?? 0,
+      };
+    } catch {
+      return {
+        status: "offline" as const,
+        count: null,
+        interactionHeat: null,
+      };
+    }
+  })();
+
+  const [mongo, redis, personMemory] = await Promise.all([
+    mongoPromise,
+    redisPromise,
+    personMemoryPromise,
+  ]);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    environment: isDev() ? "development" : "production",
+    chat: {
+      enabled: config.message.web.enabled,
+      identity: ownerName,
+      model: config.llm.models.chat[0].model,
+    },
+    mongo,
+    redis,
+    personMemory,
+  };
+}

--- a/packages/web/lib/components/app-shell/index.tsx
+++ b/packages/web/lib/components/app-shell/index.tsx
@@ -16,6 +16,7 @@ import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetClose, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { InterfacePreferencesProvider } from "@/lib/components/interface-preferences";
 import { cn } from "@/lib/utils";
 
 const NAVIGATION_ITEMS = [
@@ -150,7 +151,7 @@ export function AppShell({ children, showInternalPages }: AppShellProps) {
           sidebarCollapsed ? "md:pl-16" : "md:pl-[220px]",
         )}
       >
-        {children}
+        <InterfacePreferencesProvider>{children}</InterfacePreferencesProvider>
       </div>
     </Sheet>
   );

--- a/packages/web/lib/components/interface-preferences.tsx
+++ b/packages/web/lib/components/interface-preferences.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { createContext, type ReactNode, useContext, useEffect, useMemo, useState } from "react";
+
+const SHOW_MESSAGE_TIME_KEY = "yuiju:show-message-time";
+const REDUCE_MOTION_KEY = "yuiju:reduce-motion";
+
+interface InterfacePreferences {
+  showMessageTime: boolean;
+  reduceMotion: boolean;
+}
+
+interface InterfacePreferencesContextValue extends InterfacePreferences {
+  setShowMessageTime: (value: boolean) => void;
+  setReduceMotion: (value: boolean) => void;
+}
+
+const InterfacePreferencesContext = createContext<InterfacePreferencesContextValue | null>(null);
+
+function applyPreferences(preferences: InterfacePreferences): void {
+  document.documentElement.dataset.showMessageTime = String(preferences.showMessageTime);
+  document.documentElement.dataset.reduceMotion = String(preferences.reduceMotion);
+}
+
+export function InterfacePreferencesProvider({ children }: { children: ReactNode }) {
+  const [preferences, setPreferences] = useState<InterfacePreferences>({
+    showMessageTime: true,
+    reduceMotion: false,
+  });
+
+  useEffect(() => {
+    const storedPreferences = {
+      showMessageTime: localStorage.getItem(SHOW_MESSAGE_TIME_KEY) !== "false",
+      reduceMotion: localStorage.getItem(REDUCE_MOTION_KEY) === "true",
+    };
+    setPreferences(storedPreferences);
+    applyPreferences(storedPreferences);
+  }, []);
+
+  const value = useMemo<InterfacePreferencesContextValue>(
+    () => ({
+      ...preferences,
+      setShowMessageTime: (showMessageTime) => {
+        const nextPreferences = { ...preferences, showMessageTime };
+        localStorage.setItem(SHOW_MESSAGE_TIME_KEY, String(showMessageTime));
+        setPreferences(nextPreferences);
+        applyPreferences(nextPreferences);
+      },
+      setReduceMotion: (reduceMotion) => {
+        const nextPreferences = { ...preferences, reduceMotion };
+        localStorage.setItem(REDUCE_MOTION_KEY, String(reduceMotion));
+        setPreferences(nextPreferences);
+        applyPreferences(nextPreferences);
+      },
+    }),
+    [preferences],
+  );
+
+  return (
+    <InterfacePreferencesContext.Provider value={value}>
+      {children}
+    </InterfacePreferencesContext.Provider>
+  );
+}
+
+export function useInterfacePreferences(): InterfacePreferencesContextValue {
+  const preferences = useContext(InterfacePreferencesContext);
+  if (!preferences) {
+    throw new Error("useInterfacePreferences must be used inside InterfacePreferencesProvider");
+  }
+  return preferences;
+}

--- a/packages/web/lib/message-internal-api.ts
+++ b/packages/web/lib/message-internal-api.ts
@@ -1,0 +1,34 @@
+import "server-only";
+
+import { getYuijuConfig } from "@yuiju/utils/config/config";
+import {
+  type WebChatMessageInput,
+  type WebChatResult,
+  webChatResultSchema,
+} from "@yuiju/utils/types/web-chat";
+
+function getMessageInternalApiUrl(pathname: string): URL {
+  const { host, port } = getYuijuConfig().message.internalApi;
+  return new URL(pathname, `http://${host}:${port}`);
+}
+
+export async function sendWebChatMessage(input: WebChatMessageInput): Promise<WebChatResult> {
+  const response = await fetch(getMessageInternalApiUrl("/internal/web/messages"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`message internal API returned ${response.status}`);
+  }
+
+  return webChatResultSchema.parse(await response.json());
+}
+
+export function fetchWebChatSticker(key: string): Promise<Response> {
+  return fetch(getMessageInternalApiUrl(`/internal/web/stickers/${encodeURIComponent(key)}`), {
+    cache: "no-store",
+  });
+}

--- a/yuiju.config.json.example
+++ b/yuiju.config.json.example
@@ -39,6 +39,11 @@
     }
   },
   "message": {
+    "web": {
+      "enabled": false,
+      "ownerId": "web-user",
+      "ownerName": "主人"
+    },
     "proactive": {
       "onebotGroupTargetId": 838986741,
       "larkGroupTargetId": "xxx"


### PR DESCRIPTION
## 依赖关系

- 依赖 #116 提供的 `message.web` 配置。
- 当前为 stacked PR；#116 合并前，GitHub 对比会暂时包含其核心提交。合并后会 rebase，使本 PR 只保留设置相关差异。

## 本次改动

迁移 fork 中已有的本地设置页与界面偏好，不重新设计：

- 新增 `/settings`，展示运行环境、聊天模型、Web 身份以及 MongoDB、Redis、人物记忆状态
- 公开展示模式下隐藏设置页
- 增加“显示消息时间”和“减少动态效果”本地偏好
- 通过 AppShell 中的 Provider 将偏好应用到页面
- 不展示 API Key、Token、数据库连接串等敏感配置

## 明确不包含

- Web 聊天页面和消息通道实现
- 聊天历史持久化
- 地图、角色资料或性能改动
- 测试文件和测试基础设施

## 验证

- Biome lint
- Oxlint
- Next typegen
- Web TypeScript 检查
- Next.js production build（生成动态 `/settings`）
- `git diff --check`