### PR TITLE
feat(web): 迁移现有 Web 聊天页面

### DIFF
--- a/packages/message/src/internal-api.ts
+++ b/packages/message/src/internal-api.ts
@@ -4,6 +4,7 @@ import type LarkBot from "@satorijs/adapter-lark";
 import type OneBotBot from "@yuiju/satorijs-adapter-onebot";
 import { SUBJECT_NAME } from "@yuiju/utils";
 import { getYuijuConfig } from "@yuiju/utils/config/config";
+import { webChatMessageInputSchema } from "@yuiju/utils/types/web-chat";
 import { Hono } from "hono";
 import { llmManager } from "@/llm/manager";
 import { stickerState } from "@/state/sticker";
@@ -14,6 +15,7 @@ import {
   createStoredSatoriGroupBotMessage,
 } from "@/utils/message/satori";
 import type { StoredSatoriGroupMessage } from "@/utils/message/types";
+import { chatThroughWebChannel, getWebChatSticker } from "@/web-chat";
 
 type MessagePlatform = "onebot" | "lark";
 
@@ -78,6 +80,43 @@ export function startMessageInternalApi(input: InternalApiInput) {
         key: sticker.key,
         description: sticker.description,
       })),
+    });
+  });
+
+  app.post("/internal/web/messages", async (context) => {
+    if (!config.message.web.enabled) {
+      return context.json({ error: { code: "WEB_CHAT_DISABLED" } }, 403);
+    }
+
+    let body: unknown;
+    try {
+      body = await context.req.json();
+    } catch {
+      return context.json({ error: { code: "INVALID_WEB_CHAT_MESSAGE" } }, 400);
+    }
+
+    const parsedMessage = webChatMessageInputSchema.safeParse(body);
+    if (!parsedMessage.success) {
+      return context.json({ error: { code: "INVALID_WEB_CHAT_MESSAGE" } }, 400);
+    }
+
+    const result = await chatThroughWebChannel(parsedMessage.data);
+    return context.json(result);
+  });
+
+  app.get("/internal/web/stickers/:key", (context) => {
+    if (!config.message.web.enabled) {
+      return context.json({ error: { code: "WEB_CHAT_DISABLED" } }, 403);
+    }
+
+    const sticker = getWebChatSticker(context.req.param("key"));
+    if (!sticker) {
+      return context.body(null, 404);
+    }
+
+    return context.body(new Uint8Array(sticker.fileBuffer), 200, {
+      "Cache-Control": "private, max-age=86400",
+      "Content-Type": sticker.contentType,
     });
   });
 

--- a/packages/message/src/web-chat.ts
+++ b/packages/message/src/web-chat.ts
@@ -1,0 +1,141 @@
+import { extname } from "node:path";
+import { h } from "@satorijs/core";
+import { getYuijuConfig } from "@yuiju/utils/config/config";
+import { SUBJECT_NAME } from "@yuiju/utils/constants/character";
+import type {
+  WebChatMessageInput,
+  WebChatReplyPart,
+  WebChatResult,
+} from "@yuiju/utils/types/web-chat";
+import { llmManager } from "@/llm/manager";
+import { stickerState } from "@/state/sticker";
+import { buildSatoriPrivateSessionKey } from "@/utils/message/satori";
+import type { HistoryMessageSegment, StoredSatoriPrivateMessage } from "@/utils/message/types";
+
+function createWebPrivateMessage(input: WebChatMessageInput): StoredSatoriPrivateMessage {
+  const { ownerId, ownerName } = getYuijuConfig().message.web;
+
+  return {
+    source: "satori",
+    scene: "private",
+    platform: "web",
+    messageId: input.messageId,
+    channelId: ownerId,
+    sessionId: buildSatoriPrivateSessionKey("web", ownerId),
+    sessionLabel: ownerName,
+    sender: {
+      id: ownerId,
+      displayName: ownerName,
+      isSelf: false,
+    },
+    timestamp: input.sentAt,
+    elements: [h.text(input.text)],
+    content: [{ type: "text", data: { text: input.text } }],
+  };
+}
+
+function projectWebReplyContent(elements: h[]): HistoryMessageSegment[] {
+  return elements.map((element) => {
+    if (element.type === "text") {
+      return { type: "text", data: { text: String(element.attrs.content ?? "") } };
+    }
+
+    const sticker = stickerState.getByKey(String(element.attrs.summary ?? ""));
+    return {
+      type: "image",
+      data: { description: sticker?.description },
+    };
+  });
+}
+
+function appendWebReplyParts(parts: WebChatReplyPart[], elements: h[], needsLineBreak: boolean) {
+  if (needsLineBreak && elements.length > 0) {
+    parts.push({ type: "text", text: "\n" });
+  }
+
+  for (const element of elements) {
+    if (element.type === "text") {
+      parts.push({ type: "text", text: String(element.attrs.content ?? "") });
+      continue;
+    }
+
+    if (element.type === "image") {
+      const key = String(element.attrs.summary ?? "");
+      parts.push({
+        type: "sticker",
+        key,
+        url: `/api/chat/stickers/${encodeURIComponent(key)}`,
+      });
+    }
+  }
+}
+
+export async function chatThroughWebChannel(input: WebChatMessageInput): Promise<WebChatResult> {
+  const sourceMessage = createWebPrivateMessage(input);
+  await llmManager.recordPrivateMessage(sourceMessage);
+
+  const result = await llmManager.chatWithLLM(sourceMessage);
+  if (result.status === "cancelled") {
+    return { status: "superseded" };
+  }
+  if (result.status === "failed") {
+    return { status: "failed" };
+  }
+  if (!llmManager.isLatestPrivateChatRequest(sourceMessage.sessionId, result.requestId)) {
+    return { status: "superseded" };
+  }
+  if (!result.shouldReply || !result.reply.trim()) {
+    return { status: "no-reply" };
+  }
+
+  const parts: WebChatReplyPart[] = [];
+  const replyLines = result.reply.split("\n").filter((line) => line.trim().length > 0);
+  const createdAt = Date.now();
+
+  for (const [lineIndex, line] of replyLines.entries()) {
+    const elements = stickerState.buildSatoriElementsFromLine(line);
+    if (!elements.length) {
+      continue;
+    }
+
+    appendWebReplyParts(parts, elements, parts.length > 0);
+    await llmManager.recordPrivateMessage({
+      ...sourceMessage,
+      messageId: `${input.messageId}:reply:${lineIndex}`,
+      sender: {
+        id: "web:yuiju",
+        displayName: SUBJECT_NAME,
+        isSelf: true,
+      },
+      elements,
+      timestamp: createdAt,
+      content: projectWebReplyContent(elements),
+    });
+  }
+
+  return {
+    status: "replied",
+    reply: {
+      id: `${input.messageId}:reply`,
+      parts,
+      createdAt,
+    },
+  };
+}
+
+export function getWebChatSticker(key: string) {
+  const sticker = stickerState.getByKey(key);
+  if (!sticker) {
+    return null;
+  }
+
+  const extension = extname(sticker.absoluteUri).toLowerCase();
+  if (extension !== ".png" && extension !== ".webp") {
+    throw new Error(`unsupported Web sticker format: ${extension}`);
+  }
+
+  return {
+    fileBuffer: sticker.fileBuffer,
+    contentType: extension === ".png" ? "image/png" : "image/webp",
+  };
+}

--- a/packages/utils/src/config/config-schema.ts
+++ b/packages/utils/src/config/config-schema.ts
@@ -18,6 +18,15 @@ export interface YuijuMessageInternalApiConfig {
 }
 
 /**
+ * Web 私聊渠道配置。
+ */
+export interface YuijuMessageWebConfig {
+  enabled: boolean;
+  ownerId: string;
+  ownerName: string;
+}
+
+/**
  * OneBot 消息平台配置。
  */
 export interface YuijuOneBotConfig extends YuijuMessageWebSocketReconnectConfig {
@@ -72,6 +81,7 @@ export interface YuijuMessageConfig {
   onebot: YuijuOneBotConfig;
   lark: YuijuLarkConfig;
   internalApi: YuijuMessageInternalApiConfig;
+  web: YuijuMessageWebConfig;
   proactive: {
     onebotGroupTargetId?: number;
     larkGroupTargetId?: string;
@@ -186,6 +196,12 @@ const yuijuMessageInternalApiConfigSchema: z.ZodType<YuijuMessageInternalApiConf
   port: z.number(),
 });
 
+const yuijuMessageWebConfigSchema: z.ZodType<YuijuMessageWebConfig> = z.strictObject({
+  enabled: z.boolean(),
+  ownerId: z.string().trim().min(1),
+  ownerName: z.string().trim().min(1),
+});
+
 const yuijuOneBotConfigSchema: z.ZodType<YuijuOneBotConfig> = z.object({
   ...yuijuMessageWebSocketReconnectConfigShape,
   protocol: z.literal("ws"),
@@ -218,6 +234,7 @@ const yuijuMessageConfigSchema: z.ZodType<YuijuMessageConfig> = z.object({
   onebot: yuijuOneBotConfigSchema,
   lark: yuijuLarkConfigSchema,
   internalApi: yuijuMessageInternalApiConfigSchema,
+  web: yuijuMessageWebConfigSchema,
   proactive: z.object({
     onebotGroupTargetId: z.number().optional(),
     larkGroupTargetId: z.string().optional(),

--- a/packages/utils/src/types/web-chat.ts
+++ b/packages/utils/src/types/web-chat.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+export const webChatMessageInputSchema = z.strictObject({
+  messageId: z.string().trim().min(1).max(120),
+  text: z.string().trim().min(1).max(2000),
+  sentAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+});
+
+export type WebChatMessageInput = z.infer<typeof webChatMessageInputSchema>;
+
+export const webChatReplyPartSchema = z.discriminatedUnion("type", [
+  z.strictObject({
+    type: z.literal("text"),
+    text: z.string(),
+  }),
+  z.strictObject({
+    type: z.literal("sticker"),
+    key: z.string().regex(/^[a-zA-Z0-9_-]+$/),
+    url: z.string().startsWith("/api/chat/stickers/"),
+  }),
+]);
+
+export type WebChatReplyPart = z.infer<typeof webChatReplyPartSchema>;
+
+export const webChatResultSchema = z.discriminatedUnion("status", [
+  z.strictObject({
+    status: z.literal("replied"),
+    reply: z.strictObject({
+      id: z.string().min(1),
+      parts: z.array(webChatReplyPartSchema).min(1),
+      createdAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+    }),
+  }),
+  z.strictObject({ status: z.literal("no-reply") }),
+  z.strictObject({ status: z.literal("failed") }),
+  z.strictObject({ status: z.literal("superseded") }),
+]);
+
+export type WebChatResult = z.infer<typeof webChatResultSchema>;

--- a/packages/web/app/api/chat/messages/route.ts
+++ b/packages/web/app/api/chat/messages/route.ts
@@ -1,0 +1,56 @@
+import { getYuijuConfig } from "@yuiju/utils/config/config";
+import { webChatMessageInputSchema } from "@yuiju/utils/types/web-chat";
+import { sendWebChatMessage } from "@/lib/message-internal-api";
+import { isPublicDeployment } from "@/lib/public-deployment";
+
+export const runtime = "nodejs";
+export const maxDuration = 120;
+
+type ChatErrorCode = "INVALID_MESSAGE" | "CHAT_DISABLED" | "CHAT_FAILED" | "MESSAGE_SUPERSEDED";
+
+function errorResponse(status: number, code: ChatErrorCode, message: string) {
+  return Response.json({ error: { code, message } }, { status });
+}
+
+export async function POST(request: Request) {
+  if (isPublicDeployment() || !getYuijuConfig().message.web.enabled) {
+    return errorResponse(403, "CHAT_DISABLED", "Web 私聊渠道未启用");
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse(400, "INVALID_MESSAGE", "请求体必须是有效 JSON");
+  }
+
+  const input = webChatMessageInputSchema.safeParse(body);
+  if (!input.success) {
+    return errorResponse(400, "INVALID_MESSAGE", "消息格式不正确");
+  }
+
+  let result: Awaited<ReturnType<typeof sendWebChatMessage>>;
+  try {
+    result = await sendWebChatMessage(input.data);
+  } catch (error) {
+    console.error("Web chat internal API request failed", error);
+    return errorResponse(502, "CHAT_FAILED", "悠酱暂时无法组织回复");
+  }
+
+  if (result.status === "failed") {
+    return errorResponse(500, "CHAT_FAILED", "悠酱暂时无法组织回复");
+  }
+  if (result.status === "superseded") {
+    return errorResponse(409, "MESSAGE_SUPERSEDED", "这条消息已被更新的消息替代");
+  }
+  if (result.status === "no-reply") {
+    return Response.json({ data: { status: "NO_REPLY" } });
+  }
+
+  return Response.json({
+    data: {
+      status: "REPLIED",
+      reply: result.reply,
+    },
+  });
+}

--- a/packages/web/app/api/chat/stickers/[key]/route.ts
+++ b/packages/web/app/api/chat/stickers/[key]/route.ts
@@ -1,0 +1,38 @@
+import { getYuijuConfig } from "@yuiju/utils/config/config";
+import { fetchWebChatSticker } from "@/lib/message-internal-api";
+import { isPublicDeployment } from "@/lib/public-deployment";
+
+export const runtime = "nodejs";
+
+export async function GET(_request: Request, context: { params: Promise<{ key: string }> }) {
+  if (isPublicDeployment() || !getYuijuConfig().message.web.enabled) {
+    return new Response(null, { status: 404 });
+  }
+
+  const { key } = await context.params;
+
+  try {
+    const internalResponse = await fetchWebChatSticker(key);
+    if (internalResponse.status === 404) {
+      return new Response(null, { status: 404 });
+    }
+    if (!internalResponse.ok) {
+      return new Response(null, { status: 502 });
+    }
+
+    const contentType = internalResponse.headers.get("content-type");
+    if (!contentType) {
+      return new Response(null, { status: 502 });
+    }
+
+    return new Response(internalResponse.body, {
+      headers: {
+        "Cache-Control": "private, max-age=86400",
+        "Content-Type": contentType,
+      },
+    });
+  } catch (error) {
+    console.error("Web chat sticker internal API request failed", error);
+    return new Response(null, { status: 502 });
+  }
+}

--- a/packages/web/app/chat/chat-client.tsx
+++ b/packages/web/app/chat/chat-client.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import type { WebChatReplyPart } from "@yuiju/utils/types/web-chat";
+import { ArrowUp, MapPin, Sparkles } from "lucide-react";
+import Image from "next/image";
+import { type FormEvent, useEffect, useRef, useState } from "react";
+import useSWR from "swr";
+import { fetchHomeSummary, HOME_SUMMARY_ENDPOINT } from "@/lib/api/home";
+
+type ChatMessage =
+  | { id: string; role: "user"; text: string; createdAt: number }
+  | { id: string; role: "assistant"; parts: WebChatReplyPart[]; createdAt: number }
+  | { id: string; role: "notice"; text: string; createdAt: number; tone: "quiet" | "error" };
+
+type ChatResponse =
+  | {
+      data: {
+        status: "REPLIED";
+        reply: { id: string; parts: WebChatReplyPart[]; createdAt: number };
+      };
+    }
+  | { data: { status: "NO_REPLY" } }
+  | { error: { code: string; message: string } };
+
+function formatTime(timestamp: number) {
+  return new Intl.DateTimeFormat("zh-CN", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(timestamp);
+}
+
+function StatusRail() {
+  const { data } = useSWR(HOME_SUMMARY_ENDPOINT, fetchHomeSummary);
+  const status = data?.status;
+  const plans = data?.plans;
+
+  return (
+    <aside className="relative overflow-hidden rounded-[28px] border border-[#d9e6f5] bg-white/80 p-6 shadow-[0_20px_60px_rgba(76,105,142,0.10)] max-[900px]:p-4">
+      <div className="absolute -right-14 -top-14 h-40 w-40 rounded-full bg-[#f1e4f7]/70 blur-2xl" />
+      <div className="relative flex items-center gap-4">
+        <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-[22px] bg-[#f7fbff] ring-1 ring-[#d9e6f5]">
+          <Image
+            src="/images/yuiju-pixel-idle-04.png"
+            alt="悠酱"
+            fill
+            sizes="80px"
+            className="object-cover object-top"
+            priority
+          />
+        </div>
+        <div className="min-w-0">
+          <p className="font-fusion-pixel text-[11px] tracking-[0.16em] text-[#7e8ccb]">
+            此刻的悠酱
+          </p>
+          <h1 className="mt-1 text-xl font-black tracking-tight text-[#2b2f36]">
+            {status?.behavior ?? "正在感受今天"}
+          </h1>
+          <p className="mt-2 flex items-center gap-1.5 text-sm text-[#6b7480]">
+            <MapPin className="h-3.5 w-3.5 text-[#91c4ee]" />
+            {status?.location ?? "世界里"}
+          </p>
+        </div>
+      </div>
+
+      <div className="relative mt-7 grid grid-cols-3 gap-2 max-[900px]:mt-4">
+        {[
+          ["心情", status?.mood],
+          ["体力", status?.stamina?.current],
+          ["饱腹", status?.satiety],
+        ].map(([label, value]) => (
+          <div
+            key={label}
+            className="rounded-2xl bg-[#f7fbff] px-3 py-3 text-center ring-1 ring-[#d9e6f5]/80"
+          >
+            <div className="font-fusion-pixel text-[10px] text-[#7e8ccb]">{label}</div>
+            <div className="mt-1 text-lg font-black text-[#2b2f36]">{value ?? "—"}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className="relative mt-6 border-t border-dashed border-[#d9e6f5] pt-5 max-[900px]:hidden">
+        <div className="flex items-center gap-2 text-xs font-bold text-[#7e8ccb]">
+          <Sparkles className="h-3.5 w-3.5" />
+          最近在想
+        </div>
+        <p className="mt-2 text-sm leading-6 text-[#59616c]">
+          {plans?.shortTerm?.[0] ?? plans?.longTerm ?? "先把眼前的生活认真过好。"}
+        </p>
+      </div>
+    </aside>
+  );
+}
+
+function MessageContent({ parts }: { parts: WebChatReplyPart[] }) {
+  return (
+    <div className="whitespace-pre-wrap">
+      {parts.map((part, index) =>
+        part.type === "text" ? (
+          <span key={`${index}:${part.text}`}>{part.text}</span>
+        ) : (
+          <Image
+            key={`${index}:${part.key}`}
+            src={part.url}
+            alt={part.key}
+            width={156}
+            height={156}
+            unoptimized
+            className="my-2 h-auto max-h-39 w-auto max-w-39 rounded-2xl"
+          />
+        ),
+      )}
+    </div>
+  );
+}
+
+export function ChatClient() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [draft, setDraft] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({
+      behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
+    });
+  });
+
+  async function sendMessage(event: FormEvent) {
+    event.preventDefault();
+    const text = draft.trim();
+    if (!text || isSending) {
+      return;
+    }
+
+    const messageId = crypto.randomUUID();
+    const sentAt = Date.now();
+    setMessages((current) => [
+      ...current,
+      { id: messageId, role: "user", text, createdAt: sentAt },
+    ]);
+    setDraft("");
+    setIsSending(true);
+
+    try {
+      const response = await fetch("/api/chat/messages", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ messageId, text, sentAt }),
+      });
+      const payload = (await response.json()) as ChatResponse;
+
+      if (!("data" in payload)) {
+        throw new Error(payload.error.message);
+      }
+
+      if (payload.data.status === "NO_REPLY") {
+        setMessages((current) => [
+          ...current,
+          {
+            id: `${messageId}:no-reply`,
+            role: "notice",
+            text: "她看到了，但此刻没有回复。",
+            createdAt: Date.now(),
+            tone: "quiet",
+          },
+        ]);
+        return;
+      }
+
+      const reply = payload.data.reply;
+      setMessages((current) => [
+        ...current,
+        {
+          id: reply.id,
+          role: "assistant",
+          parts: reply.parts,
+          createdAt: reply.createdAt,
+        },
+      ]);
+    } catch (error) {
+      setMessages((current) => [
+        ...current,
+        {
+          id: `${messageId}:error`,
+          role: "notice",
+          text: error instanceof Error ? error.message : "消息没有送达，请稍后再试。",
+          createdAt: Date.now(),
+          tone: "error",
+        },
+      ]);
+    } finally {
+      setIsSending(false);
+    }
+  }
+
+  return (
+    <main className="min-h-[calc(100vh-78px)] bg-[radial-gradient(circle_at_80%_10%,rgba(241,228,247,0.7),transparent_28%),linear-gradient(180deg,#f7fbff_0%,#ffffff_52%)] px-[18px] py-6">
+      <div className="mx-auto grid max-w-300 grid-cols-[300px_minmax(0,1fr)] gap-4 max-[900px]:grid-cols-1">
+        <StatusRail />
+
+        <section className="flex min-h-[calc(100vh-126px)] flex-col overflow-hidden rounded-[28px] border border-[#d9e6f5] bg-white/88 shadow-[0_20px_60px_rgba(76,105,142,0.10)] max-[900px]:min-h-[70vh]">
+          <header className="border-b border-[#d9e6f5]/80 px-6 py-5">
+            <p className="font-fusion-pixel text-[11px] tracking-[0.14em] text-[#7e8ccb]">
+              WEB 私聊
+            </p>
+            <div className="mt-1 flex items-end justify-between gap-3">
+              <h2 className="text-2xl font-black tracking-tight text-[#2b2f36]">和悠酱说说话</h2>
+              <p className="text-xs text-[#88919c]">她有自己的生活，也可能选择不回复</p>
+            </div>
+          </header>
+
+          <div className="flex-1 overflow-y-auto px-6 py-7 max-[640px]:px-4" aria-live="polite">
+            {messages.length === 0 ? (
+              <div className="mx-auto mt-[12vh] max-w-sm text-center">
+                <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-[#f1e4f7]/70 text-[#7e8ccb]">
+                  <Sparkles className="h-5 w-5" />
+                </div>
+                <p className="mt-4 text-sm leading-6 text-[#6b7480]">
+                  这里连接的是悠酱现有的记忆与生活状态。
+                  <br />
+                  从一句自然的话开始就好。
+                </p>
+              </div>
+            ) : (
+              <div className="grid gap-5">
+                {messages.map((message) => {
+                  if (message.role === "notice") {
+                    return (
+                      <p
+                        key={message.id}
+                        className={`text-center text-xs ${message.tone === "error" ? "text-[#b35d70]" : "text-[#9aa2ad]"}`}
+                        role={message.tone === "error" ? "alert" : "status"}
+                      >
+                        {message.text}
+                      </p>
+                    );
+                  }
+
+                  const isUser = message.role === "user";
+                  return (
+                    <article
+                      key={message.id}
+                      className={`flex ${isUser ? "justify-end" : "justify-start"}`}
+                    >
+                      <div
+                        className={`max-w-[78%] ${isUser ? "items-end" : "items-start"} flex flex-col`}
+                      >
+                        <div
+                          className={
+                            isUser
+                              ? "rounded-[22px_22px_6px_22px] bg-[#91c4ee] px-4 py-3 text-sm leading-6 text-[#243649] shadow-[0_8px_22px_rgba(84,142,189,0.16)]"
+                              : "rounded-[22px_22px_22px_6px] bg-[#f7fbff] px-4 py-3 text-sm leading-6 text-[#353a41] ring-1 ring-[#d9e6f5]"
+                          }
+                        >
+                          {isUser ? message.text : <MessageContent parts={message.parts} />}
+                        </div>
+                        <time className="chat-message-time mt-1.5 px-1 text-[10px] text-[#a0a7b1]">
+                          {formatTime(message.createdAt)}
+                        </time>
+                      </div>
+                    </article>
+                  );
+                })}
+                {isSending ? (
+                  <div className="flex justify-start">
+                    <div className="rounded-[22px_22px_22px_6px] bg-[#f7fbff] px-4 py-3 text-sm text-[#7e8ccb] ring-1 ring-[#d9e6f5]">
+                      正在回想最近发生的事
+                      <span className="animate-pulse motion-reduce:animate-none">…</span>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            )}
+            <div ref={endRef} />
+          </div>
+
+          <form onSubmit={sendMessage} className="border-t border-[#d9e6f5]/80 bg-white/90 p-4">
+            <div className="flex items-end gap-3 rounded-[22px] bg-[#f7fbff] p-2 ring-1 ring-[#d9e6f5] focus-within:ring-[#91c4ee]">
+              <textarea
+                value={draft}
+                onChange={(event) => setDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
+                    event.preventDefault();
+                    event.currentTarget.form?.requestSubmit();
+                  }
+                }}
+                rows={2}
+                maxLength={2000}
+                placeholder="想对悠酱说什么？"
+                className="max-h-36 min-h-12 flex-1 resize-none bg-transparent px-3 py-2 text-sm leading-6 text-[#2b2f36] outline-none placeholder:text-[#a4acb6]"
+                aria-label="聊天消息"
+              />
+              <button
+                type="submit"
+                disabled={!draft.trim() || isSending}
+                className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-[#7e8ccb] text-white shadow-[0_8px_20px_rgba(126,140,203,0.24)] transition hover:bg-[#6e7fc4] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#526da8] disabled:cursor-not-allowed disabled:opacity-35 motion-reduce:transition-none"
+                aria-label="发送消息"
+              >
+                <ArrowUp className="h-5 w-5" />
+              </button>
+            </div>
+            <p className="mt-2 px-2 text-[10px] text-[#a0a7b1]">Enter 发送 · Shift + Enter 换行</p>
+          </form>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/packages/web/app/chat/page.tsx
+++ b/packages/web/app/chat/page.tsx
@@ -1,0 +1,12 @@
+import { getYuijuConfig } from "@yuiju/utils/config/config";
+import { notFound } from "next/navigation";
+import { isPublicDeployment } from "@/lib/public-deployment";
+import { ChatClient } from "./chat-client";
+
+export default function ChatPage() {
+  if (isPublicDeployment() || !getYuijuConfig().message.web.enabled) {
+    notFound();
+  }
+
+  return <ChatClient />;
+}

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,4 +1,5 @@
 import { Analytics } from "@vercel/analytics/next";
+import { getYuijuConfig } from "@yuiju/utils/config/config";
 import type { Metadata } from "next";
 import { Toaster } from "@/components/ui/sonner";
 import { AppShell } from "@/lib/components/app-shell/index";
@@ -21,7 +22,12 @@ export default function RootLayout({
   return (
     <html lang="zh-CN">
       <body className="antialiased">
-        <AppShell showInternalPages={showInternalPages}>{children}</AppShell>
+        <AppShell
+          showInternalPages={showInternalPages}
+          showWebChat={showInternalPages && getYuijuConfig().message.web.enabled}
+        >
+          {children}
+        </AppShell>
         <Toaster />
         <Analytics />
       </body>

--- a/packages/web/lib/components/app-shell/index.tsx
+++ b/packages/web/lib/components/app-shell/index.tsx
@@ -7,6 +7,7 @@ import {
   FileText,
   House,
   Menu,
+  MessageCircle,
   PanelLeftClose,
   PanelLeftOpen,
   Settings,
@@ -20,6 +21,7 @@ import { cn } from "@/lib/utils";
 
 const NAVIGATION_ITEMS = [
   { key: "home", href: "/", label: "首页", icon: House },
+  { key: "chat", href: "/chat", label: "聊天", icon: MessageCircle },
   { key: "activity", href: "/activity", label: "动态", icon: Activity },
   { key: "diary", href: "/diary", label: "日记", icon: BookOpenText },
   { key: "logs", href: "/logs", label: "日志", icon: FileText },
@@ -72,14 +74,19 @@ function NavigationLinks({ closeDrawer, collapsed, items }: NavigationLinksProps
 interface AppShellProps {
   children: React.ReactNode;
   showInternalPages: boolean;
+  showWebChat: boolean;
 }
 
-export function AppShell({ children, showInternalPages }: AppShellProps) {
+export function AppShell({ children, showInternalPages, showWebChat }: AppShellProps) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
-  const visibleItems = NAVIGATION_ITEMS.filter(
-    (item) => showInternalPages || (item.key !== "logs" && item.key !== "memory"),
-  );
+  const visibleItems = NAVIGATION_ITEMS.filter((item) => {
+    if (item.key === "chat") {
+      return showWebChat;
+    }
+
+    return showInternalPages || (item.key !== "logs" && item.key !== "memory");
+  });
 
   return (
     <Sheet open={mobileDrawerOpen} onOpenChange={setMobileDrawerOpen}>

--- a/packages/web/lib/message-internal-api.ts
+++ b/packages/web/lib/message-internal-api.ts
@@ -1,0 +1,34 @@
+import "server-only";
+
+import { getYuijuConfig } from "@yuiju/utils/config/config";
+import {
+  type WebChatMessageInput,
+  type WebChatResult,
+  webChatResultSchema,
+} from "@yuiju/utils/types/web-chat";
+
+function getMessageInternalApiUrl(pathname: string): URL {
+  const { host, port } = getYuijuConfig().message.internalApi;
+  return new URL(pathname, `http://${host}:${port}`);
+}
+
+export async function sendWebChatMessage(input: WebChatMessageInput): Promise<WebChatResult> {
+  const response = await fetch(getMessageInternalApiUrl("/internal/web/messages"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`message internal API returned ${response.status}`);
+  }
+
+  return webChatResultSchema.parse(await response.json());
+}
+
+export function fetchWebChatSticker(key: string): Promise<Response> {
+  return fetch(getMessageInternalApiUrl(`/internal/web/stickers/${encodeURIComponent(key)}`), {
+    cache: "no-store",
+  });
+}

--- a/yuiju.config.json.example
+++ b/yuiju.config.json.example
@@ -39,6 +39,11 @@
     }
   },
   "message": {
+    "web": {
+      "enabled": false,
+      "ownerId": "web-user",
+      "ownerName": "主人"
+    },
     "proactive": {
       "onebotGroupTargetId": 838986741,
       "larkGroupTargetId": "xxx"


### PR DESCRIPTION
## 依赖关系

- 依赖 #116，请先审查、合并 Web 私聊通道与内部 API。
- 当前为 stacked PR；#116 合并前，GitHub 对比会暂时包含其核心提交。合并后会 rebase，使本 PR 只保留 UI 差异。

Related to #109

## 本次改动

迁移 fork 中已有的 Web 聊天页面，不重新设计界面：

- 新增 `/chat` 页面，保留原有角色状态侧栏、消息气泡、输入框和贴纸展示
- 调用 #116 提供的 `/api/chat/messages`
- 根据私有部署和 `message.web.enabled` 控制页面及导航入口
- 使用共享 `WebChatReplyPart` 类型，避免 Web 端重复定义协议
- 补充中文输入法 Enter 判断、键盘焦点和 reduced-motion 行为

## 明确不包含

- MongoDB 聊天历史与刷新恢复
- 设置页面
- 回复性能改动
- 测试文件和测试基础设施

## 验证

- Biome lint
- Oxlint
- Next typegen
- Web TypeScript 检查
- Next.js production build（生成 `/chat`）
- `git diff --check`