### PR TITLE
feat(web): 持久化 Web 聊天记录并支持游标分页

### DIFF
--- a/packages/message/src/internal-api.ts
+++ b/packages/message/src/internal-api.ts
@@ -4,7 +4,7 @@ import type LarkBot from "@satorijs/adapter-lark";
 import type OneBotBot from "@yuiju/satorijs-adapter-onebot";
 import { SUBJECT_NAME } from "@yuiju/utils";
 import { getYuijuConfig } from "@yuiju/utils/config/config";
-import { webChatMessageInputSchema } from "@yuiju/utils/types/web-chat";
+import { webChatHistoryQuerySchema, webChatMessageInputSchema } from "@yuiju/utils/types/web-chat";
 import { Hono } from "hono";
 import { llmManager } from "@/llm/manager";
 import { stickerState } from "@/state/sticker";
@@ -15,7 +15,7 @@ import {
   createStoredSatoriGroupBotMessage,
 } from "@/utils/message/satori";
 import type { StoredSatoriGroupMessage } from "@/utils/message/types";
-import { chatThroughWebChannel, getWebChatSticker } from "@/web-chat";
+import { chatThroughWebChannel, getWebChatHistory, getWebChatSticker } from "@/web-chat";
 
 type MessagePlatform = "onebot" | "lark";
 
@@ -102,6 +102,27 @@ export function startMessageInternalApi(input: InternalApiInput) {
 
     const result = await chatThroughWebChannel(parsedMessage.data);
     return context.json(result);
+  });
+
+  app.get("/internal/web/messages", async (context) => {
+    if (!config.message.web.enabled) {
+      return context.json({ error: { code: "WEB_CHAT_DISABLED" } }, 403);
+    }
+
+    const cursorSentAt = context.req.query("cursorSentAt");
+    const cursorId = context.req.query("cursorId");
+    const parsedQuery = webChatHistoryQuerySchema.safeParse({
+      limit: Number(context.req.query("limit")),
+      cursor:
+        cursorSentAt === undefined && cursorId === undefined
+          ? undefined
+          : { sentAt: Number(cursorSentAt), id: cursorId },
+    });
+    if (!parsedQuery.success) {
+      return context.json({ error: { code: "INVALID_WEB_CHAT_HISTORY_QUERY" } }, 400);
+    }
+
+    return context.json(await getWebChatHistory(parsedQuery.data));
   });
 
   app.get("/internal/web/stickers/:key", (context) => {

--- a/packages/message/src/web-chat.ts
+++ b/packages/message/src/web-chat.ts
@@ -2,7 +2,17 @@ import { extname } from "node:path";
 import { h } from "@satorijs/core";
 import { getYuijuConfig } from "@yuiju/utils/config/config";
 import { SUBJECT_NAME } from "@yuiju/utils/constants/character";
+import {
+  beginWebChatMessage,
+  completeWebChatMessage,
+  getWebChatMessagesPage,
+  matchesWebChatMessageInput,
+  projectStoredWebChatResult,
+} from "@yuiju/utils/db/operations/web-chat-message";
 import type {
+  WebChatHistoryMessage,
+  WebChatHistoryPage,
+  WebChatHistoryQuery,
   WebChatMessageInput,
   WebChatReplyPart,
   WebChatResult,
@@ -72,19 +82,51 @@ function appendWebReplyParts(parts: WebChatReplyPart[], elements: h[], needsLine
 
 export async function chatThroughWebChannel(input: WebChatMessageInput): Promise<WebChatResult> {
   const sourceMessage = createWebPrivateMessage(input);
-  await llmManager.recordPrivateMessage(sourceMessage);
+  const writeInput = {
+    sessionId: sourceMessage.sessionId,
+    messageId: input.messageId,
+    sender: {
+      id: sourceMessage.sender.id,
+      displayName: sourceMessage.sender.displayName,
+    },
+    text: input.text,
+    sentAt: input.sentAt,
+  };
+  const beginResult = await beginWebChatMessage(writeInput);
+  if (beginResult.status === "existing") {
+    if (!matchesWebChatMessageInput(beginResult.message, writeInput)) {
+      return { status: "message-conflict" };
+    }
+    return projectStoredWebChatResult(beginResult.message);
+  }
 
-  const result = await llmManager.chatWithLLM(sourceMessage);
+  let result: Awaited<ReturnType<typeof llmManager.chatWithLLM>>;
+  try {
+    await llmManager.recordPrivateMessage(sourceMessage);
+    result = await llmManager.chatWithLLM(sourceMessage);
+  } catch (error) {
+    await completeWebChatMessage(sourceMessage.sessionId, input.messageId, { status: "failed" });
+    throw error;
+  }
+
   if (result.status === "cancelled") {
+    await completeWebChatMessage(sourceMessage.sessionId, input.messageId, {
+      status: "superseded",
+    });
     return { status: "superseded" };
   }
   if (result.status === "failed") {
+    await completeWebChatMessage(sourceMessage.sessionId, input.messageId, { status: "failed" });
     return { status: "failed" };
   }
   if (!llmManager.isLatestPrivateChatRequest(sourceMessage.sessionId, result.requestId)) {
+    await completeWebChatMessage(sourceMessage.sessionId, input.messageId, {
+      status: "superseded",
+    });
     return { status: "superseded" };
   }
   if (!result.shouldReply || !result.reply.trim()) {
+    await completeWebChatMessage(sourceMessage.sessionId, input.messageId, { status: "no-reply" });
     return { status: "no-reply" };
   }
 
@@ -92,35 +134,114 @@ export async function chatThroughWebChannel(input: WebChatMessageInput): Promise
   const replyLines = result.reply.split("\n").filter((line) => line.trim().length > 0);
   const createdAt = Date.now();
 
-  for (const [lineIndex, line] of replyLines.entries()) {
-    const elements = stickerState.buildSatoriElementsFromLine(line);
-    if (!elements.length) {
-      continue;
-    }
+  try {
+    for (const [lineIndex, line] of replyLines.entries()) {
+      const elements = stickerState.buildSatoriElementsFromLine(line);
+      if (!elements.length) {
+        continue;
+      }
 
-    appendWebReplyParts(parts, elements, parts.length > 0);
-    await llmManager.recordPrivateMessage({
-      ...sourceMessage,
-      messageId: `${input.messageId}:reply:${lineIndex}`,
-      sender: {
-        id: "web:yuiju",
-        displayName: SUBJECT_NAME,
-        isSelf: true,
-      },
-      elements,
-      timestamp: createdAt,
-      content: projectWebReplyContent(elements),
-    });
+      appendWebReplyParts(parts, elements, parts.length > 0);
+      await llmManager.recordPrivateMessage({
+        ...sourceMessage,
+        messageId: `${input.messageId}:reply:${lineIndex}`,
+        sender: {
+          id: "web:yuiju",
+          displayName: SUBJECT_NAME,
+          isSelf: true,
+        },
+        elements,
+        timestamp: createdAt,
+        content: projectWebReplyContent(elements),
+      });
+    }
+  } catch (error) {
+    await completeWebChatMessage(sourceMessage.sessionId, input.messageId, { status: "failed" });
+    throw error;
   }
 
-  return {
+  if (parts.length === 0) {
+    await completeWebChatMessage(sourceMessage.sessionId, input.messageId, { status: "failed" });
+    throw new Error(`Web chat reply has no supported content: ${input.messageId}`);
+  }
+
+  const webResult = {
     status: "replied",
     reply: {
       id: `${input.messageId}:reply`,
       parts,
       createdAt,
     },
-  };
+  } as const;
+  await completeWebChatMessage(sourceMessage.sessionId, input.messageId, webResult);
+  return webResult;
+}
+
+export async function getWebChatHistory(query: WebChatHistoryQuery): Promise<WebChatHistoryPage> {
+  const { ownerId } = getYuijuConfig().message.web;
+  const sessionId = buildSatoriPrivateSessionKey("web", ownerId);
+  const page = await getWebChatMessagesPage({
+    sessionId,
+    limit: query.limit,
+    cursor: query.cursor,
+  });
+  const messages: WebChatHistoryMessage[] = [];
+
+  for (const document of page.messages) {
+    const createdAt = document.sentAt.getTime();
+    messages.push({
+      id: document.messageId,
+      role: "user",
+      text: document.text,
+      createdAt,
+    });
+
+    if (document.responseStatus === "pending") {
+      continue;
+    }
+    if (!document.completedAt) {
+      throw new Error(`Web chat completion time is missing: ${document.messageId}`);
+    }
+
+    if (document.responseStatus === "replied") {
+      const reply = document.reply;
+      if (!reply) {
+        throw new Error(`Web chat reply is missing: ${document.messageId}`);
+      }
+      messages.push({
+        id: reply.id,
+        role: "assistant",
+        parts: reply.parts,
+        createdAt: reply.createdAt,
+      });
+    } else if (document.responseStatus === "no-reply") {
+      messages.push({
+        id: `${document.messageId}:no-reply`,
+        role: "notice",
+        text: "她看到了，但此刻没有回复。",
+        createdAt: document.completedAt.getTime(),
+        tone: "quiet",
+      });
+    } else if (document.responseStatus === "failed") {
+      messages.push({
+        id: `${document.messageId}:failed`,
+        role: "notice",
+        text: "悠酱暂时无法组织回复。",
+        createdAt: document.completedAt.getTime(),
+        tone: "error",
+      });
+    } else if (document.responseStatus === "superseded") {
+      messages.push({
+        id: `${document.messageId}:superseded`,
+        role: "notice",
+        text: "这条消息已被更新的消息替代。",
+        createdAt: document.completedAt.getTime(),
+        tone: "quiet",
+      });
+    }
+  }
+
+  return { messages, nextCursor: page.nextCursor };
 }
 
 export function getWebChatSticker(key: string) {

--- a/packages/utils/src/db/operations/web-chat-message.ts
+++ b/packages/utils/src/db/operations/web-chat-message.ts
@@ -1,0 +1,137 @@
+import mongoose, { Types } from "mongoose";
+import type { WebChatHistoryCursor, WebChatReply, WebChatResult } from "../../types/web-chat";
+import { webChatReplySchema } from "../../types/web-chat";
+import {
+  getWebChatMessageModel,
+  type IWebChatMessage,
+  type WebChatResponseStatus,
+} from "../schema/web-chat-message.schema";
+
+export interface WebChatMessageWriteInput {
+  sessionId: string;
+  messageId: string;
+  sender: {
+    id: string;
+    displayName: string;
+  };
+  text: string;
+  sentAt: number;
+}
+
+export type BeginWebChatMessageResult =
+  | { status: "created"; message: IWebChatMessage }
+  | { status: "existing"; message: IWebChatMessage };
+
+export async function beginWebChatMessage(
+  input: WebChatMessageWriteInput,
+): Promise<BeginWebChatMessageResult> {
+  const model = await getWebChatMessageModel();
+
+  try {
+    const message = await model.create({
+      ...input,
+      sentAt: new Date(input.sentAt),
+      responseStatus: "pending",
+    });
+    return { status: "created", message };
+  } catch (error) {
+    if (!(error instanceof mongoose.mongo.MongoServerError) || error.code !== 11000) {
+      throw error;
+    }
+  }
+
+  const existing = await model
+    .findOne({ sessionId: input.sessionId, messageId: input.messageId })
+    .orFail()
+    .exec();
+  return { status: "existing", message: existing };
+}
+
+export function matchesWebChatMessageInput(
+  message: IWebChatMessage,
+  input: WebChatMessageWriteInput,
+): boolean {
+  return (
+    message.sender.id === input.sender.id &&
+    message.sender.displayName === input.sender.displayName &&
+    message.text === input.text &&
+    message.sentAt.getTime() === input.sentAt
+  );
+}
+
+export function projectStoredWebChatResult(message: IWebChatMessage): WebChatResult {
+  if (message.responseStatus === "pending") {
+    return { status: "pending-conflict" };
+  }
+  if (message.responseStatus === "replied") {
+    return { status: "replied", reply: webChatReplySchema.parse(message.reply) };
+  }
+  return { status: message.responseStatus };
+}
+
+export async function completeWebChatMessage(
+  sessionId: string,
+  messageId: string,
+  result:
+    | { status: Exclude<WebChatResponseStatus, "pending" | "replied"> }
+    | { status: "replied"; reply: WebChatReply },
+): Promise<void> {
+  const model = await getWebChatMessageModel();
+  const completedAt = new Date();
+  const update =
+    result.status === "replied"
+      ? { responseStatus: result.status, reply: result.reply, completedAt }
+      : { responseStatus: result.status, completedAt };
+  const writeResult = await model
+    .updateOne(
+      { sessionId, messageId, responseStatus: "pending" },
+      { $set: update },
+      { runValidators: true },
+    )
+    .exec();
+
+  if (writeResult.modifiedCount !== 1) {
+    const current = await model.findOne({ sessionId, messageId }).orFail().exec();
+    throw new Error(
+      `cannot complete Web chat message ${sessionId}/${messageId} from ${current.responseStatus}`,
+    );
+  }
+}
+
+export async function getWebChatMessagesPage(options: {
+  sessionId: string;
+  limit: number;
+  cursor?: WebChatHistoryCursor;
+}): Promise<{ messages: IWebChatMessage[]; nextCursor: WebChatHistoryCursor | null }> {
+  const model = await getWebChatMessageModel();
+  const filter: Record<string, unknown> = { sessionId: options.sessionId };
+
+  if (options.cursor) {
+    const cursorDate = new Date(options.cursor.sentAt);
+    filter.$or = [
+      { sentAt: { $lt: cursorDate } },
+      { sentAt: cursorDate, _id: { $lt: new Types.ObjectId(options.cursor.id) } },
+    ];
+  }
+
+  const documents = await model
+    .find(filter)
+    .sort({ sentAt: -1, _id: -1 })
+    .limit(options.limit + 1)
+    .exec();
+  const hasMore = documents.length > options.limit;
+  const messages = documents.slice(0, options.limit);
+  const oldest = messages.at(-1);
+  const chronologicalMessages: IWebChatMessage[] = [];
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message) {
+      chronologicalMessages.push(message);
+    }
+  }
+
+  return {
+    messages: chronologicalMessages,
+    nextCursor: hasMore && oldest ? { sentAt: oldest.sentAt.getTime(), id: oldest.id } : null,
+  };
+}

--- a/packages/utils/src/db/schema/web-chat-message.schema.ts
+++ b/packages/utils/src/db/schema/web-chat-message.schema.ts
@@ -1,0 +1,69 @@
+import mongoose, { type Document, Schema } from "mongoose";
+import type { WebChatReply } from "../../types/web-chat";
+import { webChatReplySchema } from "../../types/web-chat";
+import { getMongoConnection } from "../connect";
+
+export type WebChatResponseStatus = "pending" | "replied" | "no-reply" | "failed" | "superseded";
+
+export interface IWebChatMessage extends Document {
+  sessionId: string;
+  messageId: string;
+  sender: {
+    id: string;
+    displayName: string;
+  };
+  text: string;
+  sentAt: Date;
+  responseStatus: WebChatResponseStatus;
+  reply?: WebChatReply;
+  completedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const WebChatSenderSchema = new Schema(
+  {
+    id: { type: String, required: true },
+    displayName: { type: String, required: true },
+  },
+  { _id: false },
+);
+
+export const WebChatMessageSchema = new Schema<IWebChatMessage>(
+  {
+    sessionId: { type: String, required: true },
+    messageId: { type: String, required: true },
+    sender: { type: WebChatSenderSchema, required: true },
+    text: { type: String, required: true },
+    sentAt: { type: Date, required: true },
+    responseStatus: {
+      type: String,
+      required: true,
+      enum: ["pending", "replied", "no-reply", "failed", "superseded"],
+    },
+    reply: {
+      type: Schema.Types.Mixed,
+      validate: {
+        validator: (value: unknown) =>
+          value === undefined || webChatReplySchema.safeParse(value).success,
+        message: "reply must match the Web chat reply contract",
+      },
+    },
+    completedAt: { type: Date },
+  },
+  {
+    collection: "web_chat_message",
+    timestamps: true,
+  },
+);
+
+WebChatMessageSchema.index({ sessionId: 1, messageId: 1 }, { unique: true });
+WebChatMessageSchema.index({ sessionId: 1, sentAt: -1, _id: -1 });
+
+export async function getWebChatMessageModel(): Promise<mongoose.Model<IWebChatMessage>> {
+  const connection = await getMongoConnection();
+  return (
+    (connection.models.WebChatMessage as mongoose.Model<IWebChatMessage> | undefined) ??
+    connection.model<IWebChatMessage>("WebChatMessage", WebChatMessageSchema)
+  );
+}

--- a/packages/utils/src/types/web-chat.ts
+++ b/packages/utils/src/types/web-chat.ts
@@ -22,18 +22,69 @@ export const webChatReplyPartSchema = z.discriminatedUnion("type", [
 
 export type WebChatReplyPart = z.infer<typeof webChatReplyPartSchema>;
 
+export const webChatReplySchema = z.strictObject({
+  id: z.string().min(1),
+  parts: z.array(webChatReplyPartSchema).min(1),
+  createdAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+});
+
+export type WebChatReply = z.infer<typeof webChatReplySchema>;
+
 export const webChatResultSchema = z.discriminatedUnion("status", [
   z.strictObject({
     status: z.literal("replied"),
-    reply: z.strictObject({
-      id: z.string().min(1),
-      parts: z.array(webChatReplyPartSchema).min(1),
-      createdAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
-    }),
+    reply: webChatReplySchema,
   }),
   z.strictObject({ status: z.literal("no-reply") }),
   z.strictObject({ status: z.literal("failed") }),
   z.strictObject({ status: z.literal("superseded") }),
+  z.strictObject({ status: z.literal("pending-conflict") }),
+  z.strictObject({ status: z.literal("message-conflict") }),
 ]);
 
 export type WebChatResult = z.infer<typeof webChatResultSchema>;
+
+export const webChatHistoryCursorSchema = z.strictObject({
+  sentAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+  id: z.string().regex(/^[a-f\d]{24}$/i),
+});
+
+export type WebChatHistoryCursor = z.infer<typeof webChatHistoryCursorSchema>;
+
+export const webChatHistoryQuerySchema = z.strictObject({
+  limit: z.number().int().min(1).max(100),
+  cursor: webChatHistoryCursorSchema.optional(),
+});
+
+export type WebChatHistoryQuery = z.infer<typeof webChatHistoryQuerySchema>;
+
+export const webChatHistoryMessageSchema = z.discriminatedUnion("role", [
+  z.strictObject({
+    id: z.string().min(1),
+    role: z.literal("user"),
+    text: z.string(),
+    createdAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+  }),
+  z.strictObject({
+    id: z.string().min(1),
+    role: z.literal("assistant"),
+    parts: z.array(webChatReplyPartSchema).min(1),
+    createdAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+  }),
+  z.strictObject({
+    id: z.string().min(1),
+    role: z.literal("notice"),
+    text: z.string(),
+    createdAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+    tone: z.enum(["quiet", "error"]),
+  }),
+]);
+
+export type WebChatHistoryMessage = z.infer<typeof webChatHistoryMessageSchema>;
+
+export const webChatHistoryPageSchema = z.strictObject({
+  messages: z.array(webChatHistoryMessageSchema),
+  nextCursor: webChatHistoryCursorSchema.nullable(),
+});
+
+export type WebChatHistoryPage = z.infer<typeof webChatHistoryPageSchema>;

--- a/packages/web/app/api/chat/messages/route.ts
+++ b/packages/web/app/api/chat/messages/route.ts
@@ -1,12 +1,19 @@
 import { getYuijuConfig } from "@yuiju/utils/config/config";
-import { webChatMessageInputSchema } from "@yuiju/utils/types/web-chat";
-import { sendWebChatMessage } from "@/lib/message-internal-api";
+import { webChatHistoryQuerySchema, webChatMessageInputSchema } from "@yuiju/utils/types/web-chat";
+import { fetchWebChatHistory, sendWebChatMessage } from "@/lib/message-internal-api";
 import { isPublicDeployment } from "@/lib/public-deployment";
 
 export const runtime = "nodejs";
 export const maxDuration = 120;
 
-type ChatErrorCode = "INVALID_MESSAGE" | "CHAT_DISABLED" | "CHAT_FAILED" | "MESSAGE_SUPERSEDED";
+type ChatErrorCode =
+  | "INVALID_MESSAGE"
+  | "INVALID_QUERY"
+  | "CHAT_DISABLED"
+  | "CHAT_FAILED"
+  | "MESSAGE_PENDING"
+  | "MESSAGE_CONFLICT"
+  | "MESSAGE_SUPERSEDED";
 
 function errorResponse(status: number, code: ChatErrorCode, message: string) {
   return Response.json({ error: { code, message } }, { status });
@@ -43,6 +50,12 @@ export async function POST(request: Request) {
   if (result.status === "superseded") {
     return errorResponse(409, "MESSAGE_SUPERSEDED", "这条消息已被更新的消息替代");
   }
+  if (result.status === "pending-conflict") {
+    return errorResponse(409, "MESSAGE_PENDING", "这条消息仍在处理中");
+  }
+  if (result.status === "message-conflict") {
+    return errorResponse(409, "MESSAGE_CONFLICT", "相同消息 ID 的内容不一致");
+  }
   if (result.status === "no-reply") {
     return Response.json({ data: { status: "NO_REPLY" } });
   }
@@ -53,4 +66,31 @@ export async function POST(request: Request) {
       reply: result.reply,
     },
   });
+}
+
+export async function GET(request: Request) {
+  if (isPublicDeployment() || !getYuijuConfig().message.web.enabled) {
+    return errorResponse(403, "CHAT_DISABLED", "Web 私聊渠道未启用");
+  }
+
+  const searchParams = new URL(request.url).searchParams;
+  const cursorSentAt = searchParams.get("cursorSentAt");
+  const cursorId = searchParams.get("cursorId");
+  const query = webChatHistoryQuerySchema.safeParse({
+    limit: Number(searchParams.get("limit")),
+    cursor:
+      cursorSentAt === null && cursorId === null
+        ? undefined
+        : { sentAt: Number(cursorSentAt), id: cursorId },
+  });
+  if (!query.success) {
+    return errorResponse(400, "INVALID_QUERY", "历史记录游标不正确");
+  }
+
+  try {
+    return Response.json({ data: await fetchWebChatHistory(query.data) });
+  } catch (error) {
+    console.error("Web chat history internal API request failed", error);
+    return errorResponse(502, "CHAT_FAILED", "聊天记录暂时无法读取");
+  }
 }

--- a/packages/web/app/chat/chat-client.tsx
+++ b/packages/web/app/chat/chat-client.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import type { WebChatReplyPart } from "@yuiju/utils/types/web-chat";
+import type {
+  WebChatHistoryCursor,
+  WebChatHistoryMessage,
+  WebChatHistoryPage,
+  WebChatReplyPart,
+} from "@yuiju/utils/types/web-chat";
 import { ArrowUp, MapPin, Sparkles } from "lucide-react";
 import Image from "next/image";
 import { type FormEvent, useEffect, useRef, useState } from "react";
 import useSWR from "swr";
 import { fetchHomeSummary, HOME_SUMMARY_ENDPOINT } from "@/lib/api/home";
-
-type ChatMessage =
-  | { id: string; role: "user"; text: string; createdAt: number }
-  | { id: string; role: "assistant"; parts: WebChatReplyPart[]; createdAt: number }
-  | { id: string; role: "notice"; text: string; createdAt: number; tone: "quiet" | "error" };
 
 type ChatResponse =
   | {
@@ -21,6 +21,31 @@ type ChatResponse =
     }
   | { data: { status: "NO_REPLY" } }
   | { error: { code: string; message: string } };
+
+type ChatHistoryResponse =
+  | { data: WebChatHistoryPage }
+  | { error: { code: string; message: string } };
+
+const CHAT_HISTORY_ENDPOINT = "/api/chat/messages?limit=50";
+
+async function fetchChatHistory(endpoint: string): Promise<WebChatHistoryPage> {
+  const response = await fetch(endpoint);
+  const payload = (await response.json()) as ChatHistoryResponse;
+
+  if (!response.ok || !("data" in payload)) {
+    throw new Error("error" in payload ? payload.error.message : "聊天记录暂时无法读取");
+  }
+
+  return payload.data;
+}
+
+function prependUniqueMessages(
+  olderMessages: WebChatHistoryMessage[],
+  currentMessages: WebChatHistoryMessage[],
+): WebChatHistoryMessage[] {
+  const olderIds = new Set(olderMessages.map((message) => message.id));
+  return [...olderMessages, ...currentMessages.filter((message) => !olderIds.has(message.id))];
+}
 
 function formatTime(timestamp: number) {
   return new Intl.DateTimeFormat("zh-CN", {
@@ -115,16 +140,66 @@ function MessageContent({ parts }: { parts: WebChatReplyPart[] }) {
 }
 
 export function ChatClient() {
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const { data: initialHistory, error: historyError } = useSWR(
+    CHAT_HISTORY_ENDPOINT,
+    fetchChatHistory,
+  );
+  const [messages, setMessages] = useState<WebChatHistoryMessage[]>([]);
+  const [nextCursor, setNextCursor] = useState<WebChatHistoryCursor | null>(null);
+  const [isLoadingOlder, setIsLoadingOlder] = useState(false);
+  const [historyPageError, setHistoryPageError] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
   const [isSending, setIsSending] = useState(false);
   const endRef = useRef<HTMLDivElement>(null);
+  const hasHydratedHistory = useRef(false);
+  const shouldScrollToEnd = useRef(true);
 
   useEffect(() => {
+    if (!initialHistory || hasHydratedHistory.current) {
+      return;
+    }
+
+    hasHydratedHistory.current = true;
+    setMessages((current) => prependUniqueMessages(initialHistory.messages, current));
+    setNextCursor(initialHistory.nextCursor);
+  }, [initialHistory]);
+
+  useEffect(() => {
+    if (messages.length === 0) {
+      return;
+    }
+    if (!shouldScrollToEnd.current) {
+      return;
+    }
+
     endRef.current?.scrollIntoView({
       behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
     });
-  });
+    shouldScrollToEnd.current = false;
+  }, [messages]);
+
+  async function loadOlderMessages() {
+    if (!nextCursor || isLoadingOlder) {
+      return;
+    }
+
+    setIsLoadingOlder(true);
+    setHistoryPageError(null);
+    try {
+      const searchParams = new URLSearchParams({
+        limit: "50",
+        cursorSentAt: String(nextCursor.sentAt),
+        cursorId: nextCursor.id,
+      });
+      const history = await fetchChatHistory(`/api/chat/messages?${searchParams}`);
+      setMessages((current) => prependUniqueMessages(history.messages, current));
+      setNextCursor(history.nextCursor);
+    } catch (error) {
+      setHistoryPageError(error instanceof Error ? error.message : "更早的聊天记录暂时无法读取");
+    } finally {
+      setIsLoadingOlder(false);
+    }
+  }
 
   async function sendMessage(event: FormEvent) {
     event.preventDefault();
@@ -135,6 +210,7 @@ export function ChatClient() {
 
     const messageId = crypto.randomUUID();
     const sentAt = Date.now();
+    shouldScrollToEnd.current = true;
     setMessages((current) => [
       ...current,
       { id: messageId, role: "user", text, createdAt: sentAt },
@@ -155,6 +231,7 @@ export function ChatClient() {
       }
 
       if (payload.data.status === "NO_REPLY") {
+        shouldScrollToEnd.current = true;
         setMessages((current) => [
           ...current,
           {
@@ -169,6 +246,7 @@ export function ChatClient() {
       }
 
       const reply = payload.data.reply;
+      shouldScrollToEnd.current = true;
       setMessages((current) => [
         ...current,
         {
@@ -179,10 +257,11 @@ export function ChatClient() {
         },
       ]);
     } catch (error) {
+      shouldScrollToEnd.current = true;
       setMessages((current) => [
         ...current,
         {
-          id: `${messageId}:error`,
+          id: `${messageId}:failed`,
           role: "notice",
           text: error instanceof Error ? error.message : "消息没有送达，请稍后再试。",
           createdAt: Date.now(),
@@ -211,7 +290,30 @@ export function ChatClient() {
           </header>
 
           <div className="flex-1 overflow-y-auto px-6 py-7 max-[640px]:px-4" aria-live="polite">
-            {messages.length === 0 ? (
+            {nextCursor ? (
+              <div className="mb-6 flex justify-center">
+                <button
+                  type="button"
+                  disabled={isLoadingOlder}
+                  onClick={loadOlderMessages}
+                  className="rounded-full border border-[#d9e6f5] bg-white px-4 py-2 text-xs font-bold text-[#7e8ccb] transition hover:bg-[#f7fbff] disabled:cursor-wait disabled:opacity-50 motion-reduce:transition-none"
+                >
+                  {isLoadingOlder ? "正在读取…" : "加载更早的消息"}
+                </button>
+              </div>
+            ) : null}
+            {historyPageError ? (
+              <p className="mb-5 text-center text-xs text-[#b35d70]" role="alert">
+                {historyPageError}
+              </p>
+            ) : null}
+            {historyError && messages.length === 0 ? (
+              <div className="mx-auto mt-[12vh] max-w-sm text-center text-sm text-[#b35d70]">
+                {historyError instanceof Error
+                  ? historyError.message
+                  : "聊天记录暂时无法读取，请刷新重试。"}
+              </div>
+            ) : messages.length === 0 ? (
               <div className="mx-auto mt-[12vh] max-w-sm text-center">
                 <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-[#f1e4f7]/70 text-[#7e8ccb]">
                   <Sparkles className="h-5 w-5" />

--- a/packages/web/lib/message-internal-api.ts
+++ b/packages/web/lib/message-internal-api.ts
@@ -2,8 +2,11 @@ import "server-only";
 
 import { getYuijuConfig } from "@yuiju/utils/config/config";
 import {
+  type WebChatHistoryPage,
+  type WebChatHistoryQuery,
   type WebChatMessageInput,
   type WebChatResult,
+  webChatHistoryPageSchema,
   webChatResultSchema,
 } from "@yuiju/utils/types/web-chat";
 
@@ -25,6 +28,22 @@ export async function sendWebChatMessage(input: WebChatMessageInput): Promise<We
   }
 
   return webChatResultSchema.parse(await response.json());
+}
+
+export async function fetchWebChatHistory(query: WebChatHistoryQuery): Promise<WebChatHistoryPage> {
+  const url = getMessageInternalApiUrl("/internal/web/messages");
+  url.searchParams.set("limit", String(query.limit));
+  if (query.cursor) {
+    url.searchParams.set("cursorSentAt", String(query.cursor.sentAt));
+    url.searchParams.set("cursorId", query.cursor.id);
+  }
+  const response = await fetch(url, { cache: "no-store" });
+
+  if (!response.ok) {
+    throw new Error(`message internal API returned ${response.status}`);
+  }
+
+  return webChatHistoryPageSchema.parse(await response.json());
 }
 
 export function fetchWebChatSticker(key: string): Promise<Response> {


### PR DESCRIPTION
## 依赖关系

- 依赖 #116 的 Web 私聊通道与内部 API。
- 依赖 #118 的现有聊天页面。
- 当前为 stacked PR；前置 PR 合并后会 rebase，使本 PR 只保留历史持久化差异。

Fixes #111
Related to #109

## 问题

当前聊天消息只保存在页面 React state 中，刷新后会全部消失。旧原型把用户消息和回复拆成两份文档，容易出现半轮对话、终态覆盖和分页漂移，因此本 PR 没有直接迁移旧数据结构。

## 本次改动

- 新增 Mongo 集合 `web_chat_message`，每次用户请求保存为一条完整 turn 文档
- 使用 `pending → replied / no-reply / failed / superseded` 状态，终态只能通过条件更新写入一次
- 增加 `(sessionId, messageId)` 唯一索引，保证重复请求幂等
- 重复终态请求返回已保存结果；处理中请求和相同 ID 的不同输入返回明确冲突
- 回复先写入 LLM 会话与 Redis 备份，再终结 Mongo 文档，Mongo 完成前不会向浏览器报告成功
- 增加 `(sessionId, sentAt, _id)` 历史索引和游标分页
- 现有聊天页面支持首屏恢复、加载更早消息、前插与消息 ID 去重
- Redis 仍只负责 LLM 的近期上下文，不从 Mongo 回填

## 数据影响

- 只新增集合和索引，不修改、迁移或删除现有集合数据
- 不兼容旧的本地双文档原型；本 PR 不提供隐藏迁移或 fallback

## 明确不包含

- #112 的回复性能优化
- 持久化后台任务或崩溃恢复队列
- 设置页、地图或角色资料改动
- 测试文件和测试基础设施

## 验证

- Biome lint
- Oxlint
- utils、message、web TypeScript 检查
- Next typegen
- Next.js Turbopack production build（生成 `/chat`）
- `git diff --check`