### PR TITLE
feat(web): 增加角色移动速度设置

### DIFF
--- a/packages/web/app/settings/settings-client.tsx
+++ b/packages/web/app/settings/settings-client.tsx
@@ -17,7 +17,14 @@ import {
   X,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useTransition } from "react";
+import { type ChangeEvent, useEffect, useState, useTransition } from "react";
+import {
+  CHARACTER_MOVE_SPEED_MULTIPLIER_DEFAULT,
+  CHARACTER_MOVE_SPEED_MULTIPLIER_MAX,
+  CHARACTER_MOVE_SPEED_MULTIPLIER_MIN,
+  CHARACTER_MOVE_SPEED_MULTIPLIER_STEP,
+  CHARACTER_MOVE_SPEED_MULTIPLIER_STORAGE_KEY,
+} from "@/components/game-scene/game/character/character-movement-speed";
 import { useInterfacePreferences } from "@/lib/components/interface-preferences";
 import type { ServiceStatus, SettingsSnapshot } from "./settings-data";
 
@@ -147,8 +154,24 @@ function PreferenceSwitch({
 export function SettingsClient({ snapshot }: { snapshot: SettingsSnapshot }) {
   const router = useRouter();
   const [isRefreshing, startRefreshing] = useTransition();
+  const [characterMoveSpeedMultiplier, setCharacterMoveSpeedMultiplier] = useState(
+    CHARACTER_MOVE_SPEED_MULTIPLIER_DEFAULT,
+  );
   const { showMessageTime, reduceMotion, setShowMessageTime, setReduceMotion } =
     useInterfacePreferences();
+
+  useEffect(() => {
+    const storedMultiplier = localStorage.getItem(CHARACTER_MOVE_SPEED_MULTIPLIER_STORAGE_KEY);
+    if (storedMultiplier !== null) {
+      setCharacterMoveSpeedMultiplier(Number(storedMultiplier));
+    }
+  }, []);
+
+  const handleCharacterMoveSpeedChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const multiplier = Number(event.currentTarget.value);
+    setCharacterMoveSpeedMultiplier(multiplier);
+    localStorage.setItem(CHARACTER_MOVE_SPEED_MULTIPLIER_STORAGE_KEY, String(multiplier));
+  };
 
   return (
     <main className="min-h-[calc(100vh-78px)] bg-[#f7fbff] px-4 py-8 text-[#2b2f36] sm:px-6">
@@ -265,6 +288,32 @@ export function SettingsClient({ snapshot }: { snapshot: SettingsSnapshot }) {
               </h2>
             </div>
             <div className="border-t border-[#d9e6f5]">
+              <SettingsRow
+                icon={Gauge}
+                label="人物移速"
+                detail="调整月汐海岸中人物的移动速度，下次打开游戏时生效"
+                value={
+                  <div className="flex items-center gap-3">
+                    <input
+                      id="character-move-speed"
+                      type="range"
+                      min={CHARACTER_MOVE_SPEED_MULTIPLIER_MIN}
+                      max={CHARACTER_MOVE_SPEED_MULTIPLIER_MAX}
+                      step={CHARACTER_MOVE_SPEED_MULTIPLIER_STEP}
+                      value={characterMoveSpeedMultiplier}
+                      aria-label="人物移速"
+                      onChange={handleCharacterMoveSpeedChange}
+                      className="h-1.5 w-28 cursor-pointer accent-[#7e8ccb] sm:w-44"
+                    />
+                    <output
+                      htmlFor="character-move-speed"
+                      className="inline-flex min-w-11 justify-center rounded-md bg-[#f4f8fc] px-2 py-1 text-xs font-bold tabular-nums text-[#6c78b8]"
+                    >
+                      {characterMoveSpeedMultiplier}×
+                    </output>
+                  </div>
+                }
+              />
               <SettingsRow
                 icon={Clock3}
                 label="消息时间"

--- a/packages/web/components/game-scene/game-scene-client.tsx
+++ b/packages/web/components/game-scene/game-scene-client.tsx
@@ -4,6 +4,10 @@ import { Maximize2, Minimize2 } from "lucide-react";
 import type Phaser from "phaser";
 import { useEffect, useRef, useState } from "react";
 import { CHARACTER_ATLAS } from "./game/character/character-animation-constant";
+import {
+  CHARACTER_MOVE_SPEED_MULTIPLIER_DEFAULT,
+  CHARACTER_MOVE_SPEED_MULTIPLIER_STORAGE_KEY,
+} from "./game/character/character-movement-speed";
 import { createGame } from "./game/create-game";
 import {
   GAME_ACTIVE_SCENE_CHANGE_EVENT,
@@ -35,6 +39,13 @@ export function GameSceneClient() {
     let createdGame: Phaser.Game | undefined;
     let resizeObserver: ResizeObserver | undefined;
     let disposed = false;
+    const storedCharacterMoveSpeedMultiplier = localStorage.getItem(
+      CHARACTER_MOVE_SPEED_MULTIPLIER_STORAGE_KEY,
+    );
+    const characterMoveSpeedMultiplier =
+      storedCharacterMoveSpeedMultiplier === null
+        ? CHARACTER_MOVE_SPEED_MULTIPLIER_DEFAULT
+        : Number(storedCharacterMoveSpeedMultiplier);
     const characterAtlasImage = new Image();
     characterAtlasImage.src = CHARACTER_ATLAS.source;
 
@@ -60,7 +71,12 @@ export function GameSceneClient() {
           return;
         }
 
-        createdGame = createGame(gameContainer, gameWidth, gameHeight);
+        createdGame = createGame(
+          gameContainer,
+          gameWidth,
+          gameHeight,
+          characterMoveSpeedMultiplier,
+        );
         createdGame.events.on(GAME_ACTIVE_SCENE_CHANGE_EVENT, setActiveSceneKey);
         setGame(createdGame);
       });

--- a/packages/web/components/game-scene/game/character/character-movement-speed.ts
+++ b/packages/web/components/game-scene/game/character/character-movement-speed.ts
@@ -1,0 +1,7 @@
+export const CHARACTER_MOVE_SPEED = 30;
+export const CHARACTER_MOVE_SPEED_MULTIPLIER_DEFAULT = 1;
+export const CHARACTER_MOVE_SPEED_MULTIPLIER_MIN = 0.5;
+export const CHARACTER_MOVE_SPEED_MULTIPLIER_MAX = 10;
+export const CHARACTER_MOVE_SPEED_MULTIPLIER_STEP = 0.25;
+export const CHARACTER_MOVE_SPEED_MULTIPLIER_STORAGE_KEY = "yuiju:character-move-speed-multiplier";
+export const CHARACTER_MOVE_SPEED_MULTIPLIER_REGISTRY_KEY = "character-move-speed-multiplier";

--- a/packages/web/components/game-scene/game/create-game.ts
+++ b/packages/web/components/game-scene/game/create-game.ts
@@ -1,4 +1,5 @@
 import Phaser from "phaser";
+import { CHARACTER_MOVE_SPEED_MULTIPLIER_REGISTRY_KEY } from "./character/character-movement-speed";
 import {
   CAMERA_FOLLOW_CHARACTER_REGISTRY_KEY,
   GAME_CONTROL_MODE_REGISTRY_KEY,
@@ -9,7 +10,12 @@ import { MoonTideCoastScene } from "./scenes/moon-tide-coast/moon-tide-coast-sce
 import { PreloadScene } from "./scenes/preload/preload-scene";
 import { WorldMapScene } from "./scenes/world-map/world-map-scene";
 
-export function createGame(parent: HTMLDivElement, width: number, height: number) {
+export function createGame(
+  parent: HTMLDivElement,
+  width: number,
+  height: number,
+  characterMoveSpeedMultiplier: number,
+) {
   return new Phaser.Game({
     type: Phaser.AUTO,
     parent,
@@ -30,6 +36,10 @@ export function createGame(parent: HTMLDivElement, width: number, height: number
     },
     callbacks: {
       preBoot(game) {
+        game.registry.set(
+          CHARACTER_MOVE_SPEED_MULTIPLIER_REGISTRY_KEY,
+          characterMoveSpeedMultiplier,
+        );
         game.registry.set(GAME_CONTROL_MODE_REGISTRY_KEY, INITIAL_GAME_CONTROL_MODE);
         game.registry.set(CAMERA_FOLLOW_CHARACTER_REGISTRY_KEY, INITIAL_CAMERA_FOLLOW_CHARACTER);
       },

--- a/packages/web/components/game-scene/game/scenes/moon-tide-coast/moon-tide-coast-scene.ts
+++ b/packages/web/components/game-scene/game/scenes/moon-tide-coast/moon-tide-coast-scene.ts
@@ -8,6 +8,10 @@ import {
   CHARACTER_WINK_ANIMATION_KEYS,
 } from "../../character/character-animation-constant";
 import { CharacterAutoWander } from "../../character/character-auto-wander";
+import {
+  CHARACTER_MOVE_SPEED,
+  CHARACTER_MOVE_SPEED_MULTIPLIER_REGISTRY_KEY,
+} from "../../character/character-movement-speed";
 import { GridPathfinder } from "../../navigation/grid-pathfinder";
 import {
   GAME_ACTIVE_SCENE_CHANGE_EVENT,
@@ -61,8 +65,6 @@ const CAMERA_ZOOM = 1.5;
 const CAMERA_FOLLOW_OFFSET_Y = 32;
 // 每帧向角色位置靠近的比例；越接近 1，跟随响应越快。
 const CAMERA_FOLLOW_LERP = 0.08;
-// 角色自动和手动行走共用的速度，单位为场景逻辑像素/秒。
-const CHARACTER_MOVE_SPEED = 30;
 // EasyStar 寻路网格的单格边长，单位为场景逻辑像素。
 const NAVIGATION_CELL_SIZE = 16;
 // 随机目的地与角色当前位置之间允许的最短直线距离。
@@ -90,6 +92,7 @@ export class MoonTideCoastScene extends Phaser.Scene {
   };
   private readonly cameraMovement = new Phaser.Math.Vector2();
   private readonly characterMovement = new Phaser.Math.Vector2();
+  private characterMoveSpeed!: number;
   private character!: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
   private characterAutoWander!: CharacterAutoWander;
   private characterShadow!: Phaser.GameObjects.Sprite;
@@ -119,6 +122,8 @@ export class MoonTideCoastScene extends Phaser.Scene {
   }
 
   create() {
+    this.characterMoveSpeed =
+      CHARACTER_MOVE_SPEED * this.registry.get(CHARACTER_MOVE_SPEED_MULTIPLIER_REGISTRY_KEY);
     this.game.events.emit(GAME_ACTIVE_SCENE_CHANGE_EVENT, MOON_TIDE_COAST_SCENE_KEY);
     this.cameras.main.fadeIn(200, 73, 50, 71);
 
@@ -223,7 +228,7 @@ export class MoonTideCoastScene extends Phaser.Scene {
     this.characterAutoWander = new CharacterAutoWander(
       pathfinder,
       {
-        speed: CHARACTER_MOVE_SPEED,
+        speed: this.characterMoveSpeed,
         minimumDestinationDistance: CHARACTER_WANDER_MINIMUM_DESTINATION_DISTANCE,
         idleDurationMin: CHARACTER_WANDER_IDLE_DURATION_MIN,
         idleDurationMax: CHARACTER_WANDER_IDLE_DURATION_MAX,
@@ -326,9 +331,9 @@ export class MoonTideCoastScene extends Phaser.Scene {
         this.startCameraFollow();
       }
       if (horizontalDirection !== 0) {
-        this.characterMovement.set(horizontalDirection * CHARACTER_MOVE_SPEED, 0);
+        this.characterMovement.set(horizontalDirection * this.characterMoveSpeed, 0);
       } else {
-        this.characterMovement.set(0, verticalDirection * CHARACTER_MOVE_SPEED);
+        this.characterMovement.set(0, verticalDirection * this.characterMoveSpeed);
       }
       this.character.setVelocity(this.characterMovement.x, this.characterMovement.y);
       this.playWalkAnimation(this.characterMovement);


### PR DESCRIPTION
## 背景

月汐海岸场景中的角色移动速度目前固定为常量，Web 设置页无法按本地使用习惯调整。

## 改动内容

- 设置页新增“人物移速”滑块，范围为 `0.5×–10×`，步长为 `0.25`
- 设置值保存在当前浏览器的 `localStorage`
- 游戏启动时读取倍率，并写入 Phaser Registry
- 月汐海岸场景统一按“基础速度 × 倍率”计算手动移动与自动漫游速度
- 设置文案明确提示下次打开游戏时生效

## 数据流与副作用

`设置页滑块 → localStorage → GameSceneClient → createGame → Phaser Registry → MoonTideCoastScene`

副作用仅限浏览器 `localStorage` 写入和 Phaser 运行时 Registry 写入。

## 不在本次范围

- 服务端同步
- 游戏运行中的热更新
- 其他场景的移动速度
- 新增测试/E2E 基础设施

## 验证

- Biome check
- Oxlint correctness / suspicious
- Next route type generation
- Web TypeScript check
- Next production build
- Git diff check